### PR TITLE
sk-j9m: Define data models

### DIFF
--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -71,20 +71,24 @@ mod tests {
     #[test]
     fn test_insert_and_get_score() {
         let db = InMemoryDb::new();
-        let score = Score::new("Team A".to_string(), "Team B".to_string());
+        let user_id = Uuid::new_v4();
+        let game_id = Uuid::new_v4();
+        let score = Score::new(user_id, game_id, 100);
         let id = score.id;
 
         db.insert_score(score).unwrap();
         let retrieved = db.get_score(&id).unwrap();
 
         assert!(retrieved.is_some());
-        assert_eq!(retrieved.unwrap().home_team, "Team A");
+        assert_eq!(retrieved.unwrap().score, 100);
     }
 
     #[test]
     fn test_delete_score() {
         let db = InMemoryDb::new();
-        let score = Score::new("Team A".to_string(), "Team B".to_string());
+        let user_id = Uuid::new_v4();
+        let game_id = Uuid::new_v4();
+        let score = Score::new(user_id, game_id, 200);
         let id = score.id;
 
         db.insert_score(score).unwrap();

--- a/src/models/error.rs
+++ b/src/models/error.rs
@@ -1,7 +1,151 @@
 //! Error types for the scorekeeper API.
 
 use actix_web::{HttpResponse, ResponseError};
+use serde::{Deserialize, Serialize};
+use std::fmt;
 use thiserror::Error;
+
+/// The body of an error response.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ErrorBody {
+    /// Error code identifier.
+    pub code: String,
+    /// Human-readable error message.
+    pub message: String,
+}
+
+impl ErrorBody {
+    /// Creates a new error body.
+    pub fn new(code: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            code: code.into(),
+            message: message.into(),
+        }
+    }
+}
+
+/// Standard error response wrapper.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ErrorResponse {
+    /// The error details.
+    pub error: ErrorBody,
+}
+
+impl ErrorResponse {
+    /// Creates a new error response.
+    pub fn new(code: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            error: ErrorBody::new(code, message),
+        }
+    }
+
+    /// Creates a not found error response.
+    pub fn not_found(message: impl Into<String>) -> Self {
+        Self::new("NOT_FOUND", message)
+    }
+
+    /// Creates a bad request error response.
+    pub fn bad_request(message: impl Into<String>) -> Self {
+        Self::new("BAD_REQUEST", message)
+    }
+
+    /// Creates an unauthorized error response.
+    pub fn unauthorized(message: impl Into<String>) -> Self {
+        Self::new("UNAUTHORIZED", message)
+    }
+
+    /// Creates an internal server error response.
+    pub fn internal_error(message: impl Into<String>) -> Self {
+        Self::new("INTERNAL_ERROR", message)
+    }
+}
+
+impl fmt::Display for ErrorResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}: {}", self.error.code, self.error.message)
+    }
+}
+
+/// Details about a specific validation error.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ValidationDetail {
+    /// The field that failed validation.
+    pub field: String,
+    /// Description of the validation error.
+    pub message: String,
+}
+
+impl ValidationDetail {
+    /// Creates a new validation detail.
+    pub fn new(field: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            field: field.into(),
+            message: message.into(),
+        }
+    }
+}
+
+/// The body of a validation error response.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ValidationErrorBody {
+    /// Error code identifier.
+    pub code: String,
+    /// Human-readable error message.
+    pub message: String,
+    /// Details about each validation error.
+    pub details: Vec<ValidationDetail>,
+}
+
+impl ValidationErrorBody {
+    /// Creates a new validation error body.
+    pub fn new(
+        code: impl Into<String>,
+        message: impl Into<String>,
+        details: Vec<ValidationDetail>,
+    ) -> Self {
+        Self {
+            code: code.into(),
+            message: message.into(),
+            details,
+        }
+    }
+}
+
+/// Validation error response wrapper.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ValidationErrorResponse {
+    /// The validation error details.
+    pub error: ValidationErrorBody,
+}
+
+impl ValidationErrorResponse {
+    /// Creates a new validation error response.
+    pub fn new(message: impl Into<String>, details: Vec<ValidationDetail>) -> Self {
+        Self {
+            error: ValidationErrorBody::new("VALIDATION_ERROR", message, details),
+        }
+    }
+
+    /// Creates a validation error response with a single detail.
+    pub fn single(field: impl Into<String>, message: impl Into<String>) -> Self {
+        Self::new(
+            "Validation failed",
+            vec![ValidationDetail::new(field, message)],
+        )
+    }
+}
+
+impl fmt::Display for ValidationErrorResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}: {} ({} errors)",
+            self.error.code,
+            self.error.message,
+            self.error.details.len()
+        )
+    }
+}
 
 /// Application-level errors.
 #[derive(Debug, Error)]
@@ -21,22 +165,27 @@ pub enum AppError {
     /// Unauthorized access.
     #[error("Unauthorized: {0}")]
     Unauthorized(String),
+
+    /// Validation error with details.
+    #[error("Validation error: {0}")]
+    ValidationError(ValidationErrorResponse),
 }
 
 impl ResponseError for AppError {
     fn error_response(&self) -> HttpResponse {
         match self {
-            AppError::NotFound(msg) => {
-                HttpResponse::NotFound().json(serde_json::json!({ "error": msg }))
-            }
+            AppError::NotFound(msg) => HttpResponse::NotFound().json(ErrorResponse::not_found(msg)),
             AppError::BadRequest(msg) => {
-                HttpResponse::BadRequest().json(serde_json::json!({ "error": msg }))
+                HttpResponse::BadRequest().json(ErrorResponse::bad_request(msg))
             }
             AppError::InternalError(msg) => {
-                HttpResponse::InternalServerError().json(serde_json::json!({ "error": msg }))
+                HttpResponse::InternalServerError().json(ErrorResponse::internal_error(msg))
             }
             AppError::Unauthorized(msg) => {
-                HttpResponse::Unauthorized().json(serde_json::json!({ "error": msg }))
+                HttpResponse::Unauthorized().json(ErrorResponse::unauthorized(msg))
+            }
+            AppError::ValidationError(validation_response) => {
+                HttpResponse::BadRequest().json(validation_response)
             }
         }
     }
@@ -47,8 +196,136 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_error_display() {
+    fn test_error_body_new() {
+        let body = ErrorBody::new("TEST_CODE", "Test message");
+        assert_eq!(body.code, "TEST_CODE");
+        assert_eq!(body.message, "Test message");
+    }
+
+    #[test]
+    fn test_error_response_new() {
+        let response = ErrorResponse::new("TEST_CODE", "Test message");
+        assert_eq!(response.error.code, "TEST_CODE");
+        assert_eq!(response.error.message, "Test message");
+    }
+
+    #[test]
+    fn test_error_response_helpers() {
+        let not_found = ErrorResponse::not_found("Resource not found");
+        assert_eq!(not_found.error.code, "NOT_FOUND");
+
+        let bad_request = ErrorResponse::bad_request("Invalid input");
+        assert_eq!(bad_request.error.code, "BAD_REQUEST");
+
+        let unauthorized = ErrorResponse::unauthorized("Not authenticated");
+        assert_eq!(unauthorized.error.code, "UNAUTHORIZED");
+
+        let internal = ErrorResponse::internal_error("Something went wrong");
+        assert_eq!(internal.error.code, "INTERNAL_ERROR");
+    }
+
+    #[test]
+    fn test_error_response_serialization() {
+        let response = ErrorResponse::not_found("Score not found");
+        let json = serde_json::to_string(&response).unwrap();
+
+        assert!(json.contains("\"code\":\"NOT_FOUND\""));
+        assert!(json.contains("\"message\":\"Score not found\""));
+        assert!(json.contains("\"error\""));
+    }
+
+    #[test]
+    fn test_error_response_deserialization() {
+        let json = r#"{"error":{"code":"NOT_FOUND","message":"Score not found"}}"#;
+        let response: ErrorResponse = serde_json::from_str(json).unwrap();
+
+        assert_eq!(response.error.code, "NOT_FOUND");
+        assert_eq!(response.error.message, "Score not found");
+    }
+
+    #[test]
+    fn test_validation_detail_new() {
+        let detail = ValidationDetail::new("email", "Invalid email format");
+        assert_eq!(detail.field, "email");
+        assert_eq!(detail.message, "Invalid email format");
+    }
+
+    #[test]
+    fn test_validation_error_response_new() {
+        let details = vec![
+            ValidationDetail::new("score", "Score must be non-negative"),
+            ValidationDetail::new("game_id", "Game ID is required"),
+        ];
+        let response = ValidationErrorResponse::new("Validation failed", details);
+
+        assert_eq!(response.error.code, "VALIDATION_ERROR");
+        assert_eq!(response.error.message, "Validation failed");
+        assert_eq!(response.error.details.len(), 2);
+    }
+
+    #[test]
+    fn test_validation_error_response_single() {
+        let response = ValidationErrorResponse::single("score", "Score is required");
+
+        assert_eq!(response.error.code, "VALIDATION_ERROR");
+        assert_eq!(response.error.details.len(), 1);
+        assert_eq!(response.error.details[0].field, "score");
+    }
+
+    #[test]
+    fn test_validation_error_response_serialization() {
+        let response = ValidationErrorResponse::single("score", "Score must be positive");
+        let json = serde_json::to_string(&response).unwrap();
+
+        assert!(json.contains("\"code\":\"VALIDATION_ERROR\""));
+        assert!(json.contains("\"field\":\"score\""));
+        assert!(json.contains("\"message\":\"Score must be positive\""));
+        assert!(json.contains("\"details\""));
+    }
+
+    #[test]
+    fn test_validation_error_response_deserialization() {
+        let json = r#"{
+            "error": {
+                "code": "VALIDATION_ERROR",
+                "message": "Validation failed",
+                "details": [
+                    {"field": "score", "message": "Score is required"}
+                ]
+            }
+        }"#;
+        let response: ValidationErrorResponse = serde_json::from_str(json).unwrap();
+
+        assert_eq!(response.error.code, "VALIDATION_ERROR");
+        assert_eq!(response.error.details.len(), 1);
+        assert_eq!(response.error.details[0].field, "score");
+    }
+
+    #[test]
+    fn test_app_error_display() {
         let err = AppError::NotFound("score".to_string());
         assert_eq!(err.to_string(), "Resource not found: score");
+
+        let err = AppError::BadRequest("invalid input".to_string());
+        assert_eq!(err.to_string(), "Bad request: invalid input");
+    }
+
+    #[test]
+    fn test_error_response_display() {
+        let response = ErrorResponse::not_found("Score not found");
+        assert_eq!(response.to_string(), "NOT_FOUND: Score not found");
+    }
+
+    #[test]
+    fn test_validation_error_response_display() {
+        let details = vec![
+            ValidationDetail::new("field1", "error1"),
+            ValidationDetail::new("field2", "error2"),
+        ];
+        let response = ValidationErrorResponse::new("Validation failed", details);
+        assert_eq!(
+            response.to_string(),
+            "VALIDATION_ERROR: Validation failed (2 errors)"
+        );
     }
 }

--- a/src/models/score.rs
+++ b/src/models/score.rs
@@ -5,57 +5,82 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 /// Represents a score entry.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Score {
     /// Unique identifier for the score.
     pub id: Uuid,
-    /// Name of the home team.
-    pub home_team: String,
-    /// Name of the away team.
-    pub away_team: String,
-    /// Home team's score.
-    pub home_score: u32,
-    /// Away team's score.
-    pub away_score: u32,
+    /// User who created the score.
+    pub user_id: Uuid,
+    /// Game this score belongs to.
+    pub game_id: Uuid,
+    /// Optional team identifier.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub team_id: Option<Uuid>,
+    /// The score value.
+    pub score: i32,
     /// When the score was created.
     pub created_at: DateTime<Utc>,
-    /// When the score was last updated.
-    pub updated_at: DateTime<Utc>,
 }
 
 impl Score {
     /// Creates a new score entry.
-    pub fn new(home_team: String, away_team: String) -> Self {
-        let now = Utc::now();
+    pub fn new(user_id: Uuid, game_id: Uuid, score: i32) -> Self {
         Self {
             id: Uuid::new_v4(),
-            home_team,
-            away_team,
-            home_score: 0,
-            away_score: 0,
-            created_at: now,
-            updated_at: now,
+            user_id,
+            game_id,
+            team_id: None,
+            score,
+            created_at: Utc::now(),
+        }
+    }
+
+    /// Creates a new score entry with a team.
+    pub fn with_team(user_id: Uuid, game_id: Uuid, team_id: Uuid, score: i32) -> Self {
+        Self {
+            id: Uuid::new_v4(),
+            user_id,
+            game_id,
+            team_id: Some(team_id),
+            score,
+            created_at: Utc::now(),
         }
     }
 }
 
 /// Request payload for creating a new score.
-#[derive(Debug, Deserialize)]
-pub struct CreateScoreRequest {
-    /// Name of the home team.
-    pub home_team: String,
-    /// Name of the away team.
-    pub away_team: String,
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ScoreCreate {
+    /// The score value.
+    pub score: i32,
+    /// Optional game identifier.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub game_id: Option<Uuid>,
 }
 
-/// Request payload for updating a score.
-#[derive(Debug, Deserialize)]
-pub struct UpdateScoreRequest {
-    /// New home team score.
-    pub home_score: Option<u32>,
-    /// New away team score.
-    pub away_score: Option<u32>,
+impl ScoreCreate {
+    /// Creates a new ScoreCreate with just a score.
+    pub fn new(score: i32) -> Self {
+        Self {
+            score,
+            game_id: None,
+        }
+    }
+
+    /// Creates a new ScoreCreate with a score and game ID.
+    pub fn with_game(score: i32, game_id: Uuid) -> Self {
+        Self {
+            score,
+            game_id: Some(game_id),
+        }
+    }
 }
+
+/// A list of scores.
+pub type ScoreList = Vec<Score>;
+
+/// A list of score creation requests.
+pub type ScoreCreateList = Vec<ScoreCreate>;
 
 #[cfg(test)]
 mod tests {
@@ -63,10 +88,127 @@ mod tests {
 
     #[test]
     fn test_new_score() {
-        let score = Score::new("Team A".to_string(), "Team B".to_string());
-        assert_eq!(score.home_team, "Team A");
-        assert_eq!(score.away_team, "Team B");
-        assert_eq!(score.home_score, 0);
-        assert_eq!(score.away_score, 0);
+        let user_id = Uuid::new_v4();
+        let game_id = Uuid::new_v4();
+        let score = Score::new(user_id, game_id, 100);
+
+        assert_eq!(score.user_id, user_id);
+        assert_eq!(score.game_id, game_id);
+        assert_eq!(score.score, 100);
+        assert!(score.team_id.is_none());
+    }
+
+    #[test]
+    fn test_score_with_team() {
+        let user_id = Uuid::new_v4();
+        let game_id = Uuid::new_v4();
+        let team_id = Uuid::new_v4();
+        let score = Score::with_team(user_id, game_id, team_id, 200);
+
+        assert_eq!(score.user_id, user_id);
+        assert_eq!(score.game_id, game_id);
+        assert_eq!(score.team_id, Some(team_id));
+        assert_eq!(score.score, 200);
+    }
+
+    #[test]
+    fn test_score_serialization() {
+        let user_id = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
+        let game_id = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
+        let score = Score {
+            id: Uuid::parse_str("7c9e6679-7425-40de-944b-e07fc1f90ae7").unwrap(),
+            user_id,
+            game_id,
+            team_id: None,
+            score: 150,
+            created_at: DateTime::parse_from_rfc3339("2024-01-15T10:30:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+        };
+
+        let json = serde_json::to_string(&score).unwrap();
+        // team_id should not be present when None
+        assert!(!json.contains("team_id"));
+        assert!(json.contains("\"score\":150"));
+    }
+
+    #[test]
+    fn test_score_deserialization() {
+        let json = r#"{
+            "id": "7c9e6679-7425-40de-944b-e07fc1f90ae7",
+            "user_id": "550e8400-e29b-41d4-a716-446655440000",
+            "game_id": "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+            "score": 150,
+            "created_at": "2024-01-15T10:30:00Z"
+        }"#;
+
+        let score: Score = serde_json::from_str(json).unwrap();
+        assert_eq!(score.score, 150);
+        assert!(score.team_id.is_none());
+    }
+
+    #[test]
+    fn test_score_with_team_serialization() {
+        let user_id = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
+        let game_id = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
+        let team_id = Uuid::parse_str("a1b2c3d4-e5f6-7890-abcd-ef1234567890").unwrap();
+        let score = Score {
+            id: Uuid::parse_str("7c9e6679-7425-40de-944b-e07fc1f90ae7").unwrap(),
+            user_id,
+            game_id,
+            team_id: Some(team_id),
+            score: 200,
+            created_at: DateTime::parse_from_rfc3339("2024-01-15T10:30:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+        };
+
+        let json = serde_json::to_string(&score).unwrap();
+        // team_id should be present when Some
+        assert!(json.contains("team_id"));
+        assert!(json.contains("a1b2c3d4-e5f6-7890-abcd-ef1234567890"));
+    }
+
+    #[test]
+    fn test_score_create_serialization() {
+        let create = ScoreCreate::new(100);
+        let json = serde_json::to_string(&create).unwrap();
+        // game_id should not be present when None
+        assert!(!json.contains("game_id"));
+        assert!(json.contains("\"score\":100"));
+    }
+
+    #[test]
+    fn test_score_create_with_game_serialization() {
+        let game_id = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
+        let create = ScoreCreate::with_game(100, game_id);
+        let json = serde_json::to_string(&create).unwrap();
+        assert!(json.contains("game_id"));
+        assert!(json.contains("6ba7b810-9dad-11d1-80b4-00c04fd430c8"));
+    }
+
+    #[test]
+    fn test_score_create_deserialization() {
+        let json = r#"{"score": 250}"#;
+        let create: ScoreCreate = serde_json::from_str(json).unwrap();
+        assert_eq!(create.score, 250);
+        assert!(create.game_id.is_none());
+    }
+
+    #[test]
+    fn test_score_list() {
+        let user_id = Uuid::new_v4();
+        let game_id = Uuid::new_v4();
+        let scores: ScoreList = vec![
+            Score::new(user_id, game_id, 100),
+            Score::new(user_id, game_id, 200),
+        ];
+        assert_eq!(scores.len(), 2);
+    }
+
+    #[test]
+    fn test_score_create_list() {
+        let creates: ScoreCreateList = vec![ScoreCreate::new(100), ScoreCreate::new(200)];
+        assert_eq!(creates.len(), 2);
     }
 }

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,6 +1,7 @@
 //! Business logic services for the scorekeeper API.
 
-use crate::models::Score;
+use crate::models::{Score, ScoreCreate};
+use uuid::Uuid;
 
 /// Service for managing scores.
 pub struct ScoreService;
@@ -11,9 +12,9 @@ impl ScoreService {
         Self
     }
 
-    /// Creates a new score.
-    pub fn create_score(&self, home_team: String, away_team: String) -> Score {
-        Score::new(home_team, away_team)
+    /// Creates a new score from a ScoreCreate request.
+    pub fn create_score(&self, user_id: Uuid, game_id: Uuid, create: &ScoreCreate) -> Score {
+        Score::new(user_id, game_id, create.score)
     }
 }
 
@@ -30,8 +31,12 @@ mod tests {
     #[test]
     fn test_create_score() {
         let service = ScoreService::new();
-        let score = service.create_score("Home".to_string(), "Away".to_string());
-        assert_eq!(score.home_team, "Home");
-        assert_eq!(score.away_team, "Away");
+        let user_id = Uuid::new_v4();
+        let game_id = Uuid::new_v4();
+        let create = ScoreCreate::new(100);
+        let score = service.create_score(user_id, game_id, &create);
+        assert_eq!(score.user_id, user_id);
+        assert_eq!(score.game_id, game_id);
+        assert_eq!(score.score, 100);
     }
 }


### PR DESCRIPTION
## Summary
- Implement Score, ScoreCreate, ScoreList types per OpenAPI spec
- Implement ErrorResponse, ValidationErrorResponse types
- Add proper serde attributes for JSON serialization
- Add unit tests

## Test Plan
- [x] cargo test passes
- [x] cargo clippy passes

Closes sk-j9m

🤖 Generated with [Claude Code](https://claude.com/claude-code)