### PR TITLE
Add Dockerfile.dev with cargo-watch for hot reload

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,30 @@
+# Development Dockerfile with hot reload using cargo-watch
+FROM rust:1.83
+
+WORKDIR /app
+
+# Install cargo-watch for hot reloading
+RUN cargo install cargo-watch
+
+# Install development dependencies
+RUN apt-get update && apt-get install -y \
+    libssl-dev \
+    pkg-config \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy manifests first for dependency caching
+COPY Cargo.toml Cargo.lock* ./
+
+# Create dummy main to build dependencies
+RUN mkdir src && echo "fn main() {}" > src/main.rs
+RUN cargo build && rm -rf src
+
+# The actual source will be mounted as a volume
+# This allows hot reload without rebuilding the image
+
+# Expose the port
+EXPOSE 8080
+
+# Use cargo-watch to rebuild and restart on file changes
+CMD ["cargo", "watch", "-x", "run"]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,22 @@
+services:
+  scorekeeper:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    ports:
+      - "8080:8080"
+    environment:
+      - HOST=0.0.0.0
+      - PORT=8080
+      - JWT_SECRET=local-development-secret
+      - BYPASS_AUTH=true
+      - RUST_LOG=debug
+    volumes:
+      - ./src:/app/src
+      - ./Cargo.toml:/app/Cargo.toml
+      - ./Cargo.lock:/app/Cargo.lock
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3


### PR DESCRIPTION
- Create Dockerfile.dev using cargo-watch for live reload
- Skip release optimizations for faster builds
- Create docker-compose.dev.yml with volume mounts
- Enables editing src/ and seeing changes without rebuild

Implements: sc-c8u