### PR TITLE
Add IAM permissions for S3 avatar bucket to OIDC role

### DIFF
--- a/infra/lib/github-oidc-stack.ts
+++ b/infra/lib/github-oidc-stack.ts
@@ -152,6 +152,20 @@ export class GitHubOidcStack extends cdk.Stack {
       })
     );
 
+    // CloudFormation read permissions (needed for CDK to get detailed errors)
+    githubActionsRole.addToPolicy(
+      new iam.PolicyStatement({
+        sid: 'CloudFormationRead',
+        effect: iam.Effect.ALLOW,
+        actions: [
+          'cloudformation:DescribeStacks',
+          'cloudformation:DescribeStackEvents',
+          'cloudformation:ListStacks',
+        ],
+        resources: ['*'],
+      })
+    );
+
     // ECS permissions
     githubActionsRole.addToPolicy(
       new iam.PolicyStatement({
@@ -314,6 +328,37 @@ export class GitHubOidcStack extends cdk.Stack {
         resources: [
           `arn:aws:s3:::cdk-*-assets-${this.account}-*`,
           `arn:aws:s3:::cdk-*-assets-${this.account}-*/*`,
+        ],
+      })
+    );
+
+    // S3 permissions for avatar bucket (created by PrerequisiteInfraStack)
+    githubActionsRole.addToPolicy(
+      new iam.PolicyStatement({
+        sid: 'S3AvatarBucket',
+        effect: iam.Effect.ALLOW,
+        actions: [
+          's3:CreateBucket',
+          's3:DeleteBucket',
+          's3:GetBucketPolicy',
+          's3:PutBucketPolicy',
+          's3:DeleteBucketPolicy',
+          's3:GetBucketAcl',
+          's3:PutBucketAcl',
+          's3:GetBucketCORS',
+          's3:PutBucketCORS',
+          's3:DeleteBucketCORS',
+          's3:GetBucketPublicAccessBlock',
+          's3:PutBucketPublicAccessBlock',
+          's3:GetEncryptionConfiguration',
+          's3:PutEncryptionConfiguration',
+          's3:GetBucketTagging',
+          's3:PutBucketTagging',
+          's3:GetBucketVersioning',
+          's3:PutBucketVersioning',
+        ],
+        resources: [
+          'arn:aws:s3:::scorekeeper-avatars',
         ],
       })
     );


### PR DESCRIPTION
## Summary

Updates the GitHub OIDC IAM role with permissions needed to deploy the S3 avatar bucket.

## Changes

**github-oidc-stack.ts:**

1. **S3 Avatar Bucket Permissions** - Adds permissions to create/manage the `scorekeeper-avatars` bucket:
   - `s3:CreateBucket`, `s3:DeleteBucket`
   - CORS, ACL, Policy, Encryption, Tagging management

2. **CloudFormation Read Permissions** - Adds wildcard read permissions so CDK can show detailed error messages:
   - `cloudformation:DescribeStacks`
   - `cloudformation:DescribeStackEvents`
   - `cloudformation:ListStacks`

## Deployment

After merging, deploy the OIDC stack to update the IAM role:

```bash
cd infra && npx cdk deploy GitHubOidcStack -c githubOrg=hannahscovill -c githubRepo=scorekeeper
```

Then retry deploying the prerequisite stack via the GitHub Actions workflow.

## Test plan
- [x] CDK builds successfully
- [x] CDK tests pass
- [ ] Deploy GitHubOidcStack
- [ ] Re-run "Deploy Prerequisite Infrastructure" workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)