### PR TITLE
Add sts:AssumeRole permission for CDK bootstrap roles

### DIFF
--- a/infra/lib/github-oidc-stack.ts
+++ b/infra/lib/github-oidc-stack.ts
@@ -313,6 +313,21 @@ export class GitHubOidcStack extends cdk.Stack {
       })
     );
 
+    // STS permissions to assume CDK bootstrap roles
+    githubActionsRole.addToPolicy(
+      new iam.PolicyStatement({
+        sid: 'AssumeBootstrapRoles',
+        effect: iam.Effect.ALLOW,
+        actions: ['sts:AssumeRole'],
+        resources: [
+          `arn:aws:iam::${this.account}:role/cdk-*-deploy-role-${this.account}-*`,
+          `arn:aws:iam::${this.account}:role/cdk-*-file-publishing-role-${this.account}-*`,
+          `arn:aws:iam::${this.account}:role/cdk-*-image-publishing-role-${this.account}-*`,
+          `arn:aws:iam::${this.account}:role/cdk-*-lookup-role-${this.account}-*`,
+        ],
+      })
+    );
+
     // S3 permissions for CDK asset bucket
     githubActionsRole.addToPolicy(
       new iam.PolicyStatement({


### PR DESCRIPTION
## Summary

Fixes the CDK deployment error where GitHub Actions can't assume CDK bootstrap roles.

## Problem

```
current credentials could not be used to assume 'arn:aws:iam::587838441384:role/cdk-hnb659fds-deploy-role-587838441384-us-west-2'
```

CDK uses bootstrap roles for deployments. The GitHub Actions role needs `sts:AssumeRole` permission for these roles.

## Changes

Adds permission to assume:
- `cdk-*-deploy-role-{account}-*`
- `cdk-*-file-publishing-role-{account}-*`
- `cdk-*-image-publishing-role-{account}-*`
- `cdk-*-lookup-role-{account}-*`

## Deployment

After merge, deploy locally:
```bash
cd infra && npx cdk deploy GitHubOidcStack -c githubOrg=hannahscovill -c githubRepo=scorekeeper
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)