### PR TITLE
Add importExisting option for pre-existing ECR repository

### DIFF
--- a/.github/workflows/deploy-prerequisite.yml
+++ b/.github/workflows/deploy-prerequisite.yml
@@ -28,6 +28,14 @@ on:
           - deploy
           - diff
           - destroy
+      import_existing:
+        description: "Import existing ECR repo instead of creating (use if ECR already exists)"
+        required: false
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
 
 concurrency:
   group: deploy-prerequisite
@@ -67,7 +75,7 @@ jobs:
       - name: CDK Diff (show changes)
         if: ${{ inputs.action == 'diff' }}
         working-directory: infra
-        run: npx cdk diff PrerequisiteInfraStack -c prerequisite=true
+        run: npx cdk diff PrerequisiteInfraStack -c prerequisite=true -c importExisting=${{ inputs.import_existing }}
         env:
           CDK_DEFAULT_ACCOUNT: ${{ vars.AWS_ACCOUNT_ID }}
           CDK_DEFAULT_REGION: ${{ env.AWS_REGION }}
@@ -75,7 +83,7 @@ jobs:
       - name: Deploy Prerequisite Infrastructure
         if: ${{ inputs.action == 'deploy' }}
         working-directory: infra
-        run: npx cdk deploy PrerequisiteInfraStack --require-approval never -c prerequisite=true
+        run: npx cdk deploy PrerequisiteInfraStack --require-approval never -c prerequisite=true -c importExisting=${{ inputs.import_existing }}
         env:
           CDK_DEFAULT_ACCOUNT: ${{ vars.AWS_ACCOUNT_ID }}
           CDK_DEFAULT_REGION: ${{ env.AWS_REGION }}

--- a/infra/bin/infra.ts
+++ b/infra/bin/infra.ts
@@ -58,12 +58,16 @@ if (isBootstrap || githubOrg) {
   });
 }
 
-// Create the Prerequisite Infrastructure stack (ECR repository)
+// Create the Prerequisite Infrastructure stack (ECR repository, S3 bucket)
 // This stack creates shared infrastructure that must exist before deployment
 // Deploy with: cdk deploy -c prerequisite=true PrerequisiteInfraStack
+// If ECR already exists: cdk deploy -c prerequisite=true -c importExisting=true PrerequisiteInfraStack
 if (isPrerequisite) {
+  const importExisting = app.node.tryGetContext('importExisting') === 'true';
+
   new PrerequisiteInfraStack(app, 'PrerequisiteInfraStack', {
     repositoryName: 'scorekeeper',
+    importExisting,
     env: {
       account: process.env.CDK_DEFAULT_ACCOUNT,
       region: process.env.CDK_DEFAULT_REGION || 'us-west-2',

--- a/infra/lib/prerequisite-infra-stack.ts
+++ b/infra/lib/prerequisite-infra-stack.ts
@@ -15,6 +15,13 @@ export interface PrerequisiteInfraStackProps extends cdk.StackProps {
    * @default 'scorekeeper-avatars'
    */
   readonly avatarBucketName?: string;
+
+  /**
+   * Whether to import existing resources instead of creating new ones.
+   * Use this when the ECR repo already exists outside of this stack.
+   * @default false
+   */
+  readonly importExisting?: boolean;
 }
 
 export class PrerequisiteInfraStack extends cdk.Stack {
@@ -28,20 +35,32 @@ export class PrerequisiteInfraStack extends cdk.Stack {
 
     const repositoryName = props?.repositoryName ?? 'scorekeeper';
     const avatarBucketName = props?.avatarBucketName ?? 'scorekeeper-avatars';
+    const importExisting = props?.importExisting ?? false;
 
-    // Create ECR Repository for the Docker image
-    const ecrRepository = new ecr.Repository(this, 'ScorekeeperEcrRepository', {
-      repositoryName,
-      removalPolicy: cdk.RemovalPolicy.RETAIN,
-      imageScanOnPush: true,
-      encryption: ecr.RepositoryEncryption.AES_256,
-      lifecycleRules: [
-        {
-          maxImageCount: 25,
-          description: 'Keep only recent images',
-        },
-      ],
-    });
+    // ECR Repository - import existing or create new
+    let ecrRepository: ecr.IRepository;
+    if (importExisting) {
+      // Import existing ECR repository (when repo exists outside this stack)
+      ecrRepository = ecr.Repository.fromRepositoryName(
+        this,
+        'ScorekeeperEcrRepository',
+        repositoryName
+      );
+    } else {
+      // Create new ECR Repository for the Docker image
+      ecrRepository = new ecr.Repository(this, 'ScorekeeperEcrRepository', {
+        repositoryName,
+        removalPolicy: cdk.RemovalPolicy.RETAIN,
+        imageScanOnPush: true,
+        encryption: ecr.RepositoryEncryption.AES_256,
+        lifecycleRules: [
+          {
+            maxImageCount: 25,
+            description: 'Keep only recent images',
+          },
+        ],
+      });
+    }
 
     // Create S3 bucket for avatar uploads
     const avatarBucket = new s3.Bucket(this, 'AvatarBucket', {


### PR DESCRIPTION
## Summary

Fixes deployment failure when ECR repository already exists outside the CDK stack.

## Problem

```
Resource of type 'AWS::ECR::Repository' with identifier 'scorekeeper' already exists
```

The ECR repo was created previously and retained (RETAIN policy), but the stack was deleted. CDK can't create a new repo with the same name.

## Solution

Add `importExisting` option that imports the existing ECR repo instead of creating a new one.

## Changes

- **prerequisite-infra-stack.ts**: Add `importExisting` prop, use `fromRepositoryName()` when true
- **bin/infra.ts**: Accept `importExisting` context variable
- **deploy-prerequisite.yml**: Add `import_existing` input (default: `true`)

## Usage

```bash
# Import existing ECR (default in workflow)
cdk deploy -c prerequisite=true -c importExisting=true PrerequisiteInfraStack

# Create new ECR (if repo doesn't exist)
cdk deploy -c prerequisite=true -c importExisting=false PrerequisiteInfraStack
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)