### PR TITLE
Add DynamoDB table for game data storage

### DIFF
--- a/infra/lib/github-oidc-stack.ts
+++ b/infra/lib/github-oidc-stack.ts
@@ -432,6 +432,30 @@ export class GitHubOidcStack extends cdk.Stack {
       })
     );
 
+    // DynamoDB permissions for scorekeeper table
+    githubActionsRole.addToPolicy(
+      new iam.PolicyStatement({
+        sid: 'DynamoDB',
+        effect: iam.Effect.ALLOW,
+        actions: [
+          'dynamodb:CreateTable',
+          'dynamodb:DeleteTable',
+          'dynamodb:DescribeTable',
+          'dynamodb:UpdateTable',
+          'dynamodb:DescribeTimeToLive',
+          'dynamodb:UpdateTimeToLive',
+          'dynamodb:DescribeContinuousBackups',
+          'dynamodb:UpdateContinuousBackups',
+          'dynamodb:ListTagsOfResource',
+          'dynamodb:TagResource',
+          'dynamodb:UntagResource',
+        ],
+        resources: [
+          `arn:aws:dynamodb:*:${this.account}:table/scorekeeper-*`,
+        ],
+      })
+    );
+
     // CloudFront permissions for Wordles static site
     githubActionsRole.addToPolicy(
       new iam.PolicyStatement({

--- a/infra/lib/infra-stack.ts
+++ b/infra/lib/infra-stack.ts
@@ -1,4 +1,5 @@
 import * as cdk from 'aws-cdk-lib/core';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import * as ecs from 'aws-cdk-lib/aws-ecs';
 import * as ecr from 'aws-cdk-lib/aws-ecr';
@@ -72,6 +73,23 @@ export class ScorekeeperStack extends cdk.Stack {
           ],
         });
 
+    // DynamoDB table for game data (single-table design)
+    const table = new dynamodb.Table(this, 'ScorekeeperTable', {
+      tableName: `scorekeeper-${environmentName}`,
+      partitionKey: { name: 'pk', type: dynamodb.AttributeType.STRING },
+      sortKey: { name: 'sk', type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      removalPolicy: cdk.RemovalPolicy.RETAIN,
+      pointInTimeRecovery: isProd,
+    });
+
+    // GSI for querying games by game_id (leaderboard queries)
+    table.addGlobalSecondaryIndex({
+      indexName: 'GameSessionIndex',
+      partitionKey: { name: 'game_id', type: dynamodb.AttributeType.STRING },
+      projectionType: dynamodb.ProjectionType.ALL,
+    });
+
     // Create VPC - using a simple 2-AZ VPC setup
     const vpc = new ec2.Vpc(this, 'ScorekeeperVpc', {
       vpcName: `scorekeeper-vpc-${environmentName}`,
@@ -117,6 +135,7 @@ export class ScorekeeperStack extends cdk.Stack {
             ENVIRONMENT: environmentName,
             RUST_LOG: isProd ? 'info' : 'debug',
             S3_AVATAR_BUCKET: avatarBucket.bucketName,
+            DYNAMODB_TABLE: table.tableName,
             AWS_REGION: this.region,
           },
         },
@@ -165,6 +184,9 @@ export class ScorekeeperStack extends cdk.Stack {
     // Grant the task role permission to upload avatars to S3
     avatarBucket.grantPut(fargateService.taskDefinition.taskRole);
 
+    // Grant the task role permission to read/write DynamoDB
+    table.grantReadWriteData(fargateService.taskDefinition.taskRole);
+
     // Outputs
     this.loadBalancerDnsName = new cdk.CfnOutput(this, 'LoadBalancerDnsName', {
       value: fargateService.loadBalancer.loadBalancerDnsName,
@@ -186,6 +208,11 @@ export class ScorekeeperStack extends cdk.Stack {
     new cdk.CfnOutput(this, 'ServiceName', {
       value: fargateService.service.serviceName,
       description: 'The name of the ECS service',
+    });
+
+    new cdk.CfnOutput(this, 'DynamoDbTableName', {
+      value: table.tableName,
+      description: 'The name of the DynamoDB table',
     });
   }
 }


### PR DESCRIPTION
## Summary
- Add `scorekeeper-{env}` DynamoDB table with pk/sk composite key
- Add `GameSessionIndex` GSI for leaderboard queries by game_id
- Grant ECS task role read/write access to table
- Pass `DYNAMODB_TABLE` env var to container
- Add DynamoDB IAM permissions to GitHub OIDC role for CDK deployments

## Test plan
- [ ] Deploy to prod and verify table is created
- [ ] Verify ECS tasks can read/write to the table

🤖 Generated with [Claude Code](https://claude.com/claude-code)