### PR TITLE
Change hosted zone to api.wordles.dev for subdomain delegation

### DIFF
--- a/infra/lib/infra-stack.ts
+++ b/infra/lib/infra-stack.ts
@@ -77,13 +77,13 @@ export class ScorekeeperStack extends cdk.Stack {
           ],
         });
 
-    // Route 53 Hosted Zone for the domain (DNS managed in Namecheap, forwarded to AWS NS)
+    // Route 53 Hosted Zone for the API subdomain (NS records configured in Namecheap)
     const domainName = this.node.tryGetContext('domainName') ?? 'wordles.dev';
     const apiSubdomain = this.node.tryGetContext('apiSubdomain') ?? 'api';
     const apiDomainName = `${apiSubdomain}.${domainName}`;
 
     const hostedZone = new route53.HostedZone(this, 'HostedZone', {
-      zoneName: domainName,
+      zoneName: apiDomainName,
     });
 
     // ACM Certificate for the API subdomain with DNS validation


### PR DESCRIPTION
## Summary
- Changes the Route 53 hosted zone from `wordles.dev` to `api.wordles.dev`
- Allows keeping Namecheap as the primary DNS for wordles.dev
- Only delegates the api subdomain to Route 53 via NS records

## Namecheap setup
After deployment, create 4 NS records in Namecheap:
```
NS record: Host: api, Value: <nameserver-1>
NS record: Host: api, Value: <nameserver-2>
NS record: Host: api, Value: <nameserver-3>
NS record: Host: api, Value: <nameserver-4>
```

Get the nameserver values from the `HostedZoneNameServers` stack output.

## Test plan
- [ ] Deploy stack
- [ ] Copy NS records from output to Namecheap
- [ ] Verify DNS propagation with `dig api.wordles.dev NS`
- [ ] Verify HTTPS works at api.wordles.dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)