### PR TITLE
fix: Read DYNAMODB_TABLE env var to connect to DynamoDB

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -87,7 +87,7 @@ impl Config {
             tls_cert_path: std::env::var("TLS_CERT_PATH").ok(),
             tls_key_path: std::env::var("TLS_KEY_PATH").ok(),
             dynamodb_endpoint_url: std::env::var("AWS_ENDPOINT_URL_DYNAMODB").ok(),
-            dynamodb_table_name: std::env::var("DYNAMODB_TABLE_NAME").ok(),
+            dynamodb_table_name: std::env::var("DYNAMODB_TABLE").ok(),
             cors_allowed_origins: std::env::var("CORS_ALLOWED_ORIGINS")
                 .map(|s| s.split(',').map(|s| s.trim().to_string()).collect())
                 .unwrap_or(default_origins),


### PR DESCRIPTION
## Summary
- Fix environment variable name mismatch preventing DynamoDB connection
- ECS task definition sets `DYNAMODB_TABLE`, but config.rs was looking for `DYNAMODB_TABLE_NAME`
- This caused the server to fall back to in-memory storage, breaking the guess endpoint in production (404 "No puzzle found")

## Root Cause
Server logs showed "Using in-memory database" because `std::env::var("DYNAMODB_TABLE_NAME")` returned `None` (ECS sets `DYNAMODB_TABLE`).

## Test plan
- [ ] Verify ECS service deploys successfully
- [ ] Check server logs for "Using DynamoDB database" instead of "Using in-memory database"
- [ ] Test guess endpoint on wordles.dev returns puzzle data

🤖 Generated with [Claude Code](https://claude.com/claude-code)