### PR TITLE
fix: Add Auth0 M2M credentials to ECS task for profile endpoints

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,9 @@
 # AWS_REGION: AWS region to deploy to (e.g., us-west-2)
 # AWS_OIDC_ROLE_ARN: The ARN of the IAM role for GitHub OIDC authentication
 #                    (e.g., arn:aws:iam::123456789012:role/GitHubActions-scorekeeper)
+# AUTH0_M2M_SECRET_ARN: The ARN of the Secrets Manager secret containing Auth0 M2M credentials
+#                       (e.g., arn:aws:secretsmanager:us-west-2:123456789012:secret:scorekeeper/auth0-m2m-xxxxx)
+#                       The secret should contain JSON: {"clientId": "...", "clientSecret": "..."}
 #
 # Note: These don't need to be secrets - the role ARN is not sensitive since
 # the OIDC trust policy restricts who can assume it.
@@ -218,7 +221,7 @@ jobs:
 
       - name: Deploy CDK stack
         working-directory: infra
-        run: npx cdk ${{ env.CDK_ACTION }} ${{ env.CDK_ACTION == 'destroy' && ' --force' || '' }} --require-approval never -c env=prod
+        run: npx cdk ${{ env.CDK_ACTION }} ${{ env.CDK_ACTION == 'destroy' && ' --force' || '' }} --require-approval never -c env=prod -c auth0M2mSecretArn=${{ vars.AUTH0_M2M_SECRET_ARN }}
         env:
           CDK_DEFAULT_ACCOUNT: ${{ vars.AWS_ACCOUNT_ID }}
           CDK_DEFAULT_REGION: ${{ env.AWS_REGION }}

--- a/infra/lib/github-oidc-stack.ts
+++ b/infra/lib/github-oidc-stack.ts
@@ -500,6 +500,21 @@ export class GitHubOidcStack extends cdk.Stack {
       })
     );
 
+    // Secrets Manager permissions for Auth0 M2M credentials
+    githubActionsRole.addToPolicy(
+      new iam.PolicyStatement({
+        sid: 'SecretsManager',
+        effect: iam.Effect.ALLOW,
+        actions: [
+          'secretsmanager:GetSecretValue',
+          'secretsmanager:DescribeSecret',
+        ],
+        resources: [
+          `arn:aws:secretsmanager:*:${this.account}:secret:scorekeeper/*`,
+        ],
+      })
+    );
+
     // CloudWatch Logs permissions
     githubActionsRole.addToPolicy(
       new iam.PolicyStatement({

--- a/infra/lib/infra-stack.ts
+++ b/infra/lib/infra-stack.ts
@@ -9,6 +9,7 @@ import * as elbv2 from 'aws-cdk-lib/aws-elasticloadbalancingv2';
 import * as route53 from 'aws-cdk-lib/aws-route53';
 import * as route53Targets from 'aws-cdk-lib/aws-route53-targets';
 import * as s3 from 'aws-cdk-lib/aws-s3';
+import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
 import { Construct } from 'constructs';
 
 export interface ScorekeeperStackProps extends cdk.StackProps {
@@ -35,6 +36,13 @@ export interface ScorekeeperStackProps extends cdk.StackProps {
    * @default false
    */
   readonly importExistingAvatarBucket?: boolean;
+
+  /**
+   * ARN of the Secrets Manager secret containing Auth0 M2M credentials.
+   * The secret should be a JSON object with 'clientId' and 'clientSecret' fields.
+   * If not provided, profile endpoints will not be available.
+   */
+  readonly auth0M2mSecretArn?: string;
 }
 
 export class ScorekeeperStack extends cdk.Stack {
@@ -142,6 +150,12 @@ export class ScorekeeperStack extends cdk.Stack {
       containerInsightsV2: isProd ? ecs.ContainerInsights.ENABLED : ecs.ContainerInsights.DISABLED,
     });
 
+    // Look up Auth0 M2M secret if ARN is provided (required for profile endpoints)
+    const auth0M2mSecretArn = props?.auth0M2mSecretArn ?? this.node.tryGetContext('auth0M2mSecretArn');
+    const auth0M2mSecret = auth0M2mSecretArn
+      ? secretsmanager.Secret.fromSecretCompleteArn(this, 'Auth0M2mSecret', auth0M2mSecretArn)
+      : undefined;
+
     // Create Fargate Service with Application Load Balancer
     const fargateService = new ecsPatterns.ApplicationLoadBalancedFargateService(
       this,
@@ -174,6 +188,15 @@ export class ScorekeeperStack extends cdk.Stack {
             DYNAMODB_TABLE: table.tableName,
             AWS_REGION: this.region,
           },
+          // Auth0 M2M credentials for profile endpoints (from Secrets Manager)
+          ...(auth0M2mSecret
+            ? {
+                secrets: {
+                  AUTH0_M2M_CLIENT_ID: ecs.Secret.fromSecretsManager(auth0M2mSecret, 'clientId'),
+                  AUTH0_M2M_CLIENT_SECRET: ecs.Secret.fromSecretsManager(auth0M2mSecret, 'clientSecret'),
+                },
+              }
+            : {}),
         },
         circuitBreaker: {
           rollback: true,


### PR DESCRIPTION
## Summary
- Profile PUT endpoint was returning 404 because Auth0 M2M credentials were missing from the ECS task
- Without these credentials, the profile endpoints are not registered at startup
- Added Secrets Manager support to store and retrieve Auth0 M2M credentials securely

## Changes
- Added `secretsmanager` import and `auth0M2mSecretArn` prop to infra-stack.ts
- Pass `AUTH0_M2M_CLIENT_ID` and `AUTH0_M2M_CLIENT_SECRET` from Secrets Manager to ECS task
- Updated deploy workflow to pass `auth0M2mSecretArn` context to CDK
- Granted GitHub Actions role permission to read Secrets Manager secrets

## Test plan
- [x] Created Secrets Manager secret with Auth0 M2M credentials
- [x] Set `AUTH0_M2M_SECRET_ARN` GitHub variable
- [x] Deployed OIDC stack with Secrets Manager permissions
- [ ] Deploy main stack (automatic after merge)
- [ ] Verify profile PUT works on wordles.dev/profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)