### PR TITLE
feat: Add POST /profile/avatar endpoint for avatar uploads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,7 +27,7 @@ checksum = "daa239b93927be1ff123eebada5a3ff23e89f0124ccb8609234e5103d5a5ae6d"
 dependencies = [
  "actix-utils",
  "actix-web",
- "derive_more",
+ "derive_more 2.1.1",
  "futures-util",
  "log",
  "once_cell",
@@ -50,10 +50,10 @@ dependencies = [
  "brotli",
  "bytes",
  "bytestring",
- "derive_more",
+ "derive_more 2.1.1",
  "encoding_rs",
  "flate2",
- "foldhash",
+ "foldhash 0.1.5",
  "futures-core",
  "h2 0.3.27",
  "http 0.2.12",
@@ -80,6 +80,44 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "actix-multipart"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5118a26dee7e34e894f7e85aa0ee5080ae4c18bf03c0e30d49a80e418f00a53"
+dependencies = [
+ "actix-multipart-derive",
+ "actix-utils",
+ "actix-web",
+ "derive_more 0.99.20",
+ "futures-core",
+ "futures-util",
+ "httparse",
+ "local-waker",
+ "log",
+ "memchr",
+ "mime",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "serde_plain",
+ "tempfile",
+ "tokio",
+]
+
+[[package]]
+name = "actix-multipart-derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e11eb847f49a700678ea2fa73daeb3208061afa2b9d1a8527c03390f4c4a1c6b"
+dependencies = [
+ "darling",
+ "parse-size",
+ "proc-macro2",
  "quote",
  "syn 2.0.114",
 ]
@@ -186,9 +224,9 @@ dependencies = [
  "bytestring",
  "cfg-if",
  "cookie",
- "derive_more",
+ "derive_more 2.1.1",
  "encoding_rs",
- "foldhash",
+ "foldhash 0.1.5",
  "futures-core",
  "futures-util",
  "impl-more",
@@ -251,6 +289,12 @@ checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
 dependencies = [
  "alloc-no-stdlib",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_system_properties"
@@ -357,6 +401,7 @@ dependencies = [
  "aws-credential-types",
  "aws-sigv4",
  "aws-smithy-async",
+ "aws-smithy-eventstream",
  "aws-smithy-http",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -393,6 +438,41 @@ dependencies = [
  "http 0.2.12",
  "regex-lite",
  "tracing",
+]
+
+[[package]]
+name = "aws-sdk-s3"
+version = "1.121.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61948728b681f88a1e49b9500469cf9e36575a424e745e2c5a651a42386e7d9c"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-checksums",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "lru",
+ "percent-encoding",
+ "regex-lite",
+ "sha2",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -472,19 +552,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69e523e1c4e8e7e8ff219d732988e22bfeae8a1cafdbe6d9eca1546fa080be7c"
 dependencies = [
  "aws-credential-types",
+ "aws-smithy-eventstream",
  "aws-smithy-http",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
+ "crypto-bigint 0.5.5",
  "form_urlencoded",
  "hex",
  "hmac",
  "http 0.2.12",
  "http 1.4.0",
+ "p256",
  "percent-encoding",
+ "ring",
  "sha2",
+ "subtle",
  "time",
  "tracing",
+ "zeroize",
 ]
 
 [[package]]
@@ -499,11 +585,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-smithy-checksums"
+version = "0.63.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23374b9170cbbcc6f5df8dc5ebb9b6c5c28a3c8f599f0e8b8b10eb6f4a5c6e74"
+dependencies = [
+ "aws-smithy-http",
+ "aws-smithy-types",
+ "bytes",
+ "crc-fast",
+ "hex",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "md-5",
+ "pin-project-lite",
+ "sha1",
+ "sha2",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-eventstream"
+version = "0.60.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc12f8b310e38cad85cf3bef45ad236f470717393c613266ce0a89512286b650"
+dependencies = [
+ "aws-smithy-types",
+ "bytes",
+ "crc32fast",
+]
+
+[[package]]
 name = "aws-smithy-http"
 version = "0.62.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "826141069295752372f8203c17f28e30c464d22899a43a0c9fd9c458d469c88b"
 dependencies = [
+ "aws-smithy-eventstream",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
@@ -668,6 +786,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -682,6 +806,12 @@ dependencies = [
  "outref",
  "vsimd",
 ]
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
@@ -792,6 +922,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -847,12 +989,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "crc-fast"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fd92aca2c6001b1bf5ba0ff84ee74ec8501b52bbef0cac80bf25a6c1d87a83d"
+dependencies = [
+ "crc",
+ "digest",
+ "rustversion",
+ "spin",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -901,12 +1092,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_more"
+version = "0.99.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
+dependencies = [
+ "convert_case 0.4.0",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -924,7 +1138,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
- "convert_case",
+ "convert_case 0.10.0",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -961,10 +1175,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "ecdsa"
+version = "0.14.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
+dependencies = [
+ "der",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
+dependencies = [
+ "base16ct",
+ "crypto-bigint 0.4.9",
+ "der",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -998,6 +1244,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "ff"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1024,6 +1280,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -1071,6 +1333,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1089,6 +1362,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-task",
  "pin-project-lite",
  "pin-utils",
@@ -1128,6 +1402,17 @@ dependencies = [
  "libc",
  "r-efi",
  "wasip2",
+]
+
+[[package]]
+name = "group"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -1173,6 +1458,11 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hex"
@@ -1654,12 +1944,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
+]
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
 ]
 
 [[package]]
@@ -1819,6 +2128,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
+name = "p256"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "sha2",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1840,6 +2160,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "parse-size"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "487f2ccd1e17ce8c1bfab3a65c89525af41cfad4c8659021a1e9a2aacd73b89b"
 
 [[package]]
 name = "pem"
@@ -1906,6 +2232,16 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs8"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
+dependencies = [
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "pkg-config"
@@ -1991,6 +2327,8 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
 
@@ -2000,8 +2338,18 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2019,6 +2367,9 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "rand_core"
@@ -2111,6 +2462,17 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
+dependencies = [
+ "crypto-bigint 0.4.9",
+ "hmac",
+ "zeroize",
 ]
 
 [[package]]
@@ -2260,13 +2622,16 @@ name = "scorekeeper"
 version = "0.1.0"
 dependencies = [
  "actix-cors",
+ "actix-multipart",
  "actix-rt",
  "actix-web",
  "async-trait",
  "aws-config",
  "aws-sdk-dynamodb",
+ "aws-sdk-s3",
  "base64",
  "chrono",
+ "futures-util",
  "jsonwebtoken",
  "once_cell",
  "phf",
@@ -2293,6 +2658,20 @@ checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "sec1"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2381,6 +2760,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_plain"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1fc6db65a611022b23a0dec6975d63fb80a302cb3388835ff02c097258d50"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2446,6 +2834,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "1.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2499,6 +2897,22 @@ checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "spin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+
+[[package]]
+name = "spki"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,10 @@ jsonwebtoken = "9"
 reqwest = { version = "0.12", features = ["json"] }
 once_cell = "1"
 aws-sdk-dynamodb = "1"
+aws-sdk-s3 = "1"
 aws-config = { version = "1", features = ["behavior-version-latest"] }
+actix-multipart = "0.7"
+futures-util = "0.3"
 async-trait = "0.1"
 base64 = "0.22"
 urlencoding = "2"

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,6 +31,8 @@ pub struct Config {
     pub dynamodb_table_name: Option<String>,
     /// Comma-separated list of allowed CORS origins.
     pub cors_allowed_origins: Vec<String>,
+    /// S3 bucket name for avatar uploads.
+    pub s3_avatar_bucket: Option<String>,
 }
 
 impl Default for Config {
@@ -54,6 +56,7 @@ impl Default for Config {
                 "https://d3g0psl1n9xo36.cloudfront.net".to_string(),
                 "https://wordles.dev".to_string(),
             ],
+            s3_avatar_bucket: None,
         }
     }
 }
@@ -91,6 +94,7 @@ impl Config {
             cors_allowed_origins: std::env::var("CORS_ALLOWED_ORIGINS")
                 .map(|s| s.split(',').map(|s| s.trim().to_string()).collect())
                 .unwrap_or(default_origins),
+            s3_avatar_bucket: std::env::var("S3_AVATAR_BUCKET").ok(),
         }
     }
 
@@ -148,6 +152,11 @@ impl Config {
     pub fn cors_allowed_origins(&self) -> &[String] {
         &self.cors_allowed_origins
     }
+
+    /// Returns the S3 avatar bucket name.
+    pub fn s3_avatar_bucket(&self) -> Option<&str> {
+        self.s3_avatar_bucket.as_deref()
+    }
 }
 
 #[cfg(test)]
@@ -182,5 +191,6 @@ mod tests {
         assert!(config
             .cors_allowed_origins
             .contains(&"https://wordles.dev".to_string()));
+        assert!(config.s3_avatar_bucket.is_none());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,8 +25,9 @@ use db::{
 use middleware::auth::JwtAuth;
 use routes::{
     create_games, get_games, get_profile, health_check, list_games, submit_guess, update_profile,
+    upload_avatar,
 };
-use services::Auth0ManagementService;
+use services::{Auth0ManagementService, S3AvatarService};
 
 /// Load TLS configuration from certificate and key files.
 fn load_tls_config(cert_path: &str, key_path: &str) -> std::io::Result<ServerConfig> {
@@ -143,6 +144,20 @@ async fn main() -> std::io::Result<()> {
         }
     };
 
+    // Initialize S3 Avatar service (requires both S3 bucket and Auth0 M2M)
+    let s3_avatar_service = if let Some(bucket) = config.s3_avatar_bucket() {
+        info!("S3 Avatar service enabled for bucket: {}", bucket);
+        let sdk_config = aws_config::load_from_env().await;
+        let s3_client = aws_sdk_s3::Client::new(&sdk_config);
+        Some(web::Data::new(S3AvatarService::new(
+            s3_client,
+            bucket.to_string(),
+        )))
+    } else {
+        info!("S3 Avatar service disabled (S3_AVATAR_BUCKET not configured)");
+        None
+    };
+
     let config_for_tls = config.clone();
     let config = web::Data::new(config);
 
@@ -188,6 +203,11 @@ async fn main() -> std::io::Result<()> {
                 .app_data(auth0.clone())
                 .service(get_profile)
                 .service(update_profile);
+
+            // Only register avatar upload if both Auth0 and S3 are configured
+            if let Some(ref s3) = s3_avatar_service {
+                app = app.app_data(s3.clone()).service(upload_avatar);
+            }
         }
 
         app

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -8,4 +8,4 @@ pub mod profile;
 pub use games::{create_games, get_games, list_games};
 pub use guess::submit_guess;
 pub use health::*;
-pub use profile::{get_profile, update_profile};
+pub use profile::{get_profile, update_profile, upload_avatar};

--- a/src/routes/profile.rs
+++ b/src/routes/profile.rs
@@ -1,12 +1,14 @@
 //! User profile route handlers.
 //! All profile data is stored in Auth0 user_metadata.
 
-use actix_web::{get, put, web, HttpResponse};
+use actix_multipart::Multipart;
+use actix_web::{get, post, put, web, HttpResponse};
+use futures_util::StreamExt;
 use serde::{Deserialize, Serialize};
 
 use crate::middleware::auth::Claims;
 use crate::models::error::AppError;
-use crate::services::Auth0ManagementService;
+use crate::services::{Auth0ManagementService, S3AvatarService};
 
 /// Request body for updating a profile.
 /// All fields are optional - only provided fields will be updated.
@@ -28,6 +30,13 @@ pub struct ProfileResponse {
     pub display_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub avatar_url: Option<String>,
+}
+
+/// Response from avatar upload endpoint.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AvatarUploadResponse {
+    pub avatar_url: String,
 }
 
 /// GET /profile - Get the current user's profile from Auth0.
@@ -72,6 +81,62 @@ pub async fn update_profile(
         display_name: user.user_metadata.as_ref().map(|m| m.display_name.clone()),
         avatar_url: user.user_metadata.and_then(|m| m.avatar_url),
     }))
+}
+
+/// POST /profile/avatar - Upload an avatar image.
+#[post("/profile/avatar")]
+pub async fn upload_avatar(
+    claims: Claims,
+    mut payload: Multipart,
+    s3_service: web::Data<S3AvatarService>,
+    auth0_service: web::Data<Auth0ManagementService>,
+) -> Result<HttpResponse, AppError> {
+    // Find the "avatar" field in the multipart payload
+    let mut file_data: Option<(Vec<u8>, String)> = None;
+
+    while let Some(item) = payload.next().await {
+        let mut field = item
+            .map_err(|e| AppError::bad_request(format!("Failed to read multipart field: {}", e)))?;
+
+        // Check if this is the "avatar" field
+        let field_name = field.name().map(|s| s.to_string());
+        if field_name.as_deref() != Some("avatar") {
+            continue;
+        }
+
+        // Get content type
+        let content_type = field
+            .content_type()
+            .map(|ct| ct.to_string())
+            .unwrap_or_default();
+
+        // Read all chunks into a buffer
+        let mut data = Vec::new();
+        while let Some(chunk) = field.next().await {
+            let chunk = chunk
+                .map_err(|e| AppError::bad_request(format!("Failed to read file chunk: {}", e)))?;
+            data.extend_from_slice(&chunk);
+        }
+
+        file_data = Some((data, content_type));
+        break;
+    }
+
+    // Ensure we got a file
+    let (data, content_type) =
+        file_data.ok_or_else(|| AppError::bad_request("Missing 'avatar' field in request"))?;
+
+    // Upload to S3
+    let avatar_url = s3_service
+        .upload_avatar(&claims.sub, data, &content_type)
+        .await?;
+
+    // Update Auth0 user metadata with the new avatar URL
+    auth0_service
+        .update_user_metadata(&claims.sub, None, Some(&avatar_url))
+        .await?;
+
+    Ok(HttpResponse::Ok().json(AvatarUploadResponse { avatar_url }))
 }
 
 #[cfg(test)]

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -2,12 +2,14 @@
 
 pub mod auth0;
 pub mod grading;
+pub mod s3_avatar;
 
 use crate::models::{Game, GameCreate};
 use uuid::Uuid;
 
 pub use auth0::Auth0ManagementService;
 pub use grading::{grade_guess, is_winning_guess};
+pub use s3_avatar::S3AvatarService;
 
 /// Service for managing games.
 pub struct GameService;

--- a/src/services/s3_avatar.rs
+++ b/src/services/s3_avatar.rs
@@ -1,0 +1,145 @@
+//! S3 Avatar upload service.
+
+use aws_sdk_s3::Client as S3Client;
+use std::time::{SystemTime, UNIX_EPOCH};
+use tracing::{debug, error};
+
+use crate::models::error::AppError;
+
+/// Maximum file size for avatar uploads (2MB).
+const MAX_FILE_SIZE: usize = 2 * 1024 * 1024;
+
+/// Allowed content types for avatar uploads.
+const ALLOWED_CONTENT_TYPES: &[&str] = &["image/jpeg", "image/png"];
+
+/// Service for uploading avatars to S3.
+pub struct S3AvatarService {
+    client: S3Client,
+    bucket: String,
+}
+
+impl S3AvatarService {
+    /// Creates a new S3AvatarService.
+    pub fn new(client: S3Client, bucket: String) -> Self {
+        Self { client, bucket }
+    }
+
+    /// Validates the content type is JPEG or PNG.
+    pub fn validate_content_type(content_type: &str) -> Result<(), AppError> {
+        if ALLOWED_CONTENT_TYPES.contains(&content_type) {
+            Ok(())
+        } else {
+            Err(AppError::bad_request(
+                "Invalid file type. Only JPEG and PNG images are allowed.",
+            ))
+        }
+    }
+
+    /// Validates the file size is within limits.
+    pub fn validate_file_size(size: usize) -> Result<(), AppError> {
+        if size == 0 {
+            Err(AppError::bad_request("Empty file"))
+        } else if size > MAX_FILE_SIZE {
+            Err(AppError::bad_request(
+                "File too large. Maximum size is 2MB.",
+            ))
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Uploads an avatar to S3 and returns the URL.
+    pub async fn upload_avatar(
+        &self,
+        user_id: &str,
+        data: Vec<u8>,
+        content_type: &str,
+    ) -> Result<String, AppError> {
+        // Validate inputs
+        Self::validate_content_type(content_type)?;
+        Self::validate_file_size(data.len())?;
+
+        // Sanitize user_id for use in S3 key (replace | with -)
+        let sanitized_user_id = user_id.replace('|', "-");
+
+        // Generate timestamp for cache busting
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_millis())
+            .unwrap_or(0);
+
+        // Determine file extension from content type
+        let ext = match content_type {
+            "image/jpeg" => "jpg",
+            "image/png" => "png",
+            _ => return Err(AppError::bad_request("Invalid content type")),
+        };
+
+        // Build S3 key
+        let key = format!("avatars/{}/{}.{}", sanitized_user_id, timestamp, ext);
+
+        debug!(
+            "Uploading avatar to S3: bucket={}, key={}",
+            self.bucket, key
+        );
+
+        // Upload to S3
+        self.client
+            .put_object()
+            .bucket(&self.bucket)
+            .key(&key)
+            .body(data.into())
+            .content_type(content_type)
+            .send()
+            .await
+            .map_err(|e| {
+                error!("Failed to upload avatar to S3: {}", e);
+                AppError::internal("Failed to upload avatar")
+            })?;
+
+        // Build and return the URL
+        let url = format!("https://{}.s3.amazonaws.com/{}", self.bucket, key);
+
+        debug!("Avatar uploaded successfully: {}", url);
+        Ok(url)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_content_type_jpeg() {
+        assert!(S3AvatarService::validate_content_type("image/jpeg").is_ok());
+    }
+
+    #[test]
+    fn test_validate_content_type_png() {
+        assert!(S3AvatarService::validate_content_type("image/png").is_ok());
+    }
+
+    #[test]
+    fn test_validate_content_type_invalid() {
+        let result = S3AvatarService::validate_content_type("image/gif");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_file_size_valid() {
+        assert!(S3AvatarService::validate_file_size(1024).is_ok());
+        assert!(S3AvatarService::validate_file_size(MAX_FILE_SIZE).is_ok());
+    }
+
+    #[test]
+    fn test_validate_file_size_empty() {
+        let result = S3AvatarService::validate_file_size(0);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_file_size_too_large() {
+        let result = S3AvatarService::validate_file_size(MAX_FILE_SIZE + 1);
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
## Summary
- Add multipart form upload endpoint (`POST /profile/avatar`) that accepts JPEG/PNG images up to 2MB
- Upload images to S3 and update Auth0 user metadata with the avatar URL
- Endpoint is only available when both Auth0 M2M credentials and S3_AVATAR_BUCKET are configured

## Changes
- Add `aws-sdk-s3`, `actix-multipart`, `futures-util` dependencies
- Add `S3_AVATAR_BUCKET` config with env var support
- Create `S3AvatarService` with content type/size validation and upload logic
- Add `upload_avatar` route handler with multipart processing
- Register endpoint conditionally when both Auth0 M2M and S3 bucket are configured

## Test plan
- [x] `cargo build` passes
- [x] `cargo test` passes (94 tests)
- [ ] Deploy and verify endpoint works on https://wordles.dev/profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)