### PR TITLE
docs: Add avatar upload endpoint to Bruno collection and OpenAPI spec

### DIFF
--- a/docs/bruno/Profile/Upload Avatar.bru
+++ b/docs/bruno/Profile/Upload Avatar.bru
@@ -1,0 +1,53 @@
+meta {
+  name: Upload Avatar
+  type: http
+  seq: 3
+}
+
+post {
+  url: https://{{baseUrl}}/profile/avatar
+  body: multipartForm
+  auth: bearer
+}
+
+headers {
+  Origin: http://localhost:3000
+}
+
+auth:bearer {
+  token: {{jwt}}
+}
+
+body:multipart-form {
+  avatar: @file(/path/to/avatar.jpg)
+}
+
+docs {
+  Uploads an avatar image for the currently authenticated user.
+
+  The image is uploaded to S3 and the URL is stored in Auth0 user_metadata.
+
+  ## Authentication
+  Requires a valid Bearer token (inherited from collection).
+
+  ## Prerequisites
+  The server must be configured with:
+  - `AUTH0_M2M_CLIENT_ID` and `AUTH0_M2M_CLIENT_SECRET`
+  - `S3_AVATAR_BUCKET`
+
+  ## Request Body
+  - `avatar` (file, required): Image file to upload
+    - Allowed types: JPEG, PNG
+    - Maximum size: 2MB
+
+  ## Responses
+  - `200`: Avatar uploaded successfully
+    ```json
+    {
+      "avatarUrl": "https://bucket.s3.amazonaws.com/avatars/auth0-123/1234567890.jpg"
+    }
+    ```
+  - `400`: Invalid file type, file too large, empty file, or missing avatar field
+  - `401`: Authentication required or invalid token
+  - `500`: S3 upload failure
+}

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -126,6 +126,54 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
 
+  /profile/avatar:
+    post:
+      summary: Upload user avatar
+      description: |
+        Upload an avatar image for the authenticated user.
+
+        The image is uploaded to S3 and the URL is stored in Auth0 user_metadata.
+        Requires both Auth0 M2M credentials and S3_AVATAR_BUCKET to be configured.
+      operationId: uploadAvatar
+      tags:
+        - Users
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - avatar
+              properties:
+                avatar:
+                  type: string
+                  format: binary
+                  description: Image file to upload (JPEG or PNG, max 2MB)
+      responses:
+        "200":
+          description: Avatar uploaded successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AvatarUploadResponse"
+              examples:
+                default:
+                  value:
+                    avatarUrl: "https://bucket.s3.amazonaws.com/avatars/auth0-123/1234567890.jpg"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          description: Internal Server Error (S3 upload failure)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: "Failed to upload avatar"
+
   /team:
     get:
       summary: Get a team
@@ -787,6 +835,22 @@ components:
           type: string
           description: The user's display name (from Auth0 user_metadata)
           example: "wordmaster42"
+        avatarUrl:
+          type: string
+          format: uri
+          description: URL to the user's avatar image
+          example: "https://bucket.s3.amazonaws.com/avatars/auth0-123/1234567890.jpg"
+
+    AvatarUploadResponse:
+      type: object
+      required:
+        - avatarUrl
+      properties:
+        avatarUrl:
+          type: string
+          format: uri
+          description: URL to the uploaded avatar image
+          example: "https://bucket.s3.amazonaws.com/avatars/auth0-123/1234567890.jpg"
 
     ErrorResponse:
       type: object


### PR DESCRIPTION
## Summary
- Add Bruno request file for testing `POST /profile/avatar`
- Add endpoint specification to openapi.yaml with multipart/form-data schema
- Add `AvatarUploadResponse` schema
- Add `avatarUrl` field to `ProfileResponse` schema

## Test plan
- [x] Bruno file created at `docs/bruno/Profile/Upload Avatar.bru`
- [x] OpenAPI spec updated with new endpoint and schemas

🤖 Generated with [Claude Code](https://claude.com/claude-code)