### PR TITLE
fix: Allow public read access for avatar images in S3

### DIFF
--- a/infra/lib/infra-stack.ts
+++ b/infra/lib/infra-stack.ts
@@ -6,6 +6,7 @@ import * as ecs from 'aws-cdk-lib/aws-ecs';
 import * as ecr from 'aws-cdk-lib/aws-ecr';
 import * as ecsPatterns from 'aws-cdk-lib/aws-ecs-patterns';
 import * as elbv2 from 'aws-cdk-lib/aws-elasticloadbalancingv2';
+import * as iam from 'aws-cdk-lib/aws-iam';
 import * as route53 from 'aws-cdk-lib/aws-route53';
 import * as route53Targets from 'aws-cdk-lib/aws-route53-targets';
 import * as s3 from 'aws-cdk-lib/aws-s3';
@@ -71,19 +72,40 @@ export class ScorekeeperStack extends cdk.Stack {
       ? s3.Bucket.fromBucketName(this, 'AvatarBucket', avatarBucketName)
       : new s3.Bucket(this, 'AvatarBucket', {
           bucketName: avatarBucketName,
-          blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+          // Allow public read access for avatar images via bucket policy
+          // Block ACLs to prevent individual object ACL changes
+          blockPublicAccess: new s3.BlockPublicAccess({
+            blockPublicAcls: true,
+            ignorePublicAcls: true,
+            blockPublicPolicy: false,
+            restrictPublicBuckets: false,
+          }),
           encryption: s3.BucketEncryption.S3_MANAGED,
           enforceSSL: true,
           removalPolicy: cdk.RemovalPolicy.RETAIN,
           cors: [
             {
               allowedMethods: [s3.HttpMethods.PUT, s3.HttpMethods.GET],
-              allowedOrigins: ['*'], // Restricted by IAM and pre-signed URLs
+              allowedOrigins: ['*'],
               allowedHeaders: ['*'],
               maxAge: 3600,
             },
           ],
         });
+
+    // Add bucket policy for public read access to avatars
+    // This works for both new and imported buckets
+    new s3.BucketPolicy(this, 'AvatarBucketPolicy', {
+      bucket: avatarBucket,
+    }).document.addStatements(
+      new iam.PolicyStatement({
+        sid: 'PublicReadAvatars',
+        effect: iam.Effect.ALLOW,
+        principals: [new iam.AnyPrincipal()],
+        actions: ['s3:GetObject'],
+        resources: [`${avatarBucket.bucketArn}/avatars/*`],
+      })
+    );
 
     // Route 53 Hosted Zone for the API subdomain (NS records configured in Namecheap)
     const domainName = this.node.tryGetContext('domainName') ?? 'wordles.dev';


### PR DESCRIPTION
## Summary
- Update `BlockPublicAccess` configuration to allow bucket policies while blocking ACLs
- Add bucket policy granting public `s3:GetObject` on `avatars/*` prefix
- Works for both new bucket creation and imported existing buckets

## Problem
Uploaded avatar images were returning 403 Forbidden because the S3 bucket had `BlockPublicAccess.BLOCK_ALL` configured, preventing any public access to the stored images.

## Solution
- Changed `BlockPublicAccess` to a custom configuration that:
  - Blocks public ACLs (for security)
  - Allows bucket policies (needed for public read access)
- Added a `BucketPolicy` resource that grants `s3:GetObject` to any principal on the `avatars/*` prefix

## Test plan
- [ ] Deploy CDK changes
- [ ] Upload a new avatar via the profile page
- [ ] Verify the avatar URL is publicly accessible (returns 200, not 403)

🤖 Generated with [Claude Code](https://claude.com/claude-code)