### PR TITLE
feat: Add admin-only PUT /puzzle endpoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,7 @@ services:
       - AUTH0_AUDIENCE=com.hannahscovill.scorekeeper
       - AUTH0_M2M_CLIENT_ID=${AUTH0_M2M_CLIENT_ID}
       - AUTH0_M2M_CLIENT_SECRET=${AUTH0_M2M_CLIENT_SECRET}
+      - ADMIN_USER_IDS=${ADMIN_USER_IDS}
       - CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:3000,https://localhost:3000,https://localhost:3000
       - RUST_LOG=debug
       - TLS_ENABLED=false

--- a/docs/bruno/Admin/Set Puzzle.bru
+++ b/docs/bruno/Admin/Set Puzzle.bru
@@ -1,0 +1,56 @@
+meta {
+  name: Set Puzzle
+  type: http
+  seq: 1
+}
+
+put {
+  url: https://{{baseUrl}}/puzzle
+  body: json
+  auth: bearer
+}
+
+headers {
+  Content-Type: application/json
+  Origin: http://localhost:3000
+}
+
+auth:bearer {
+  token: {{jwt}}
+}
+
+body:json {
+  {
+    "date": "2026-02-15",
+    "word": "crane"
+  }
+}
+
+docs {
+  Sets the puzzle answer for a specific date. This is an admin-only endpoint.
+
+  ## Authentication
+  Requires a valid Bearer token (inherited from collection).
+  The authenticated user must be in the ADMIN_USER_IDS environment variable.
+
+  ## Prerequisites
+  The server must be configured with:
+  - `ADMIN_USER_IDS`: Comma-separated list of Auth0 user IDs that are admins
+
+  ## Request Body
+  - `date` (string, required): The puzzle date in YYYY-MM-DD format
+  - `word` (string, required): The 5-letter answer word (will be lowercased)
+  - `teamId` (string, optional): Team ID for team-specific puzzles
+
+  ## Responses
+  - `200`: Puzzle answer set successfully
+    ```json
+    {
+      "date": "2026-02-15",
+      "word": "crane"
+    }
+    ```
+  - `400`: Invalid request (word not 5 letters, contains non-letters)
+  - `401`: Authentication required or invalid token
+  - `403`: User is not an administrator
+}

--- a/docs/bruno/Admin/folder.bru
+++ b/docs/bruno/Admin/folder.bru
@@ -1,0 +1,4 @@
+meta {
+  name: Admin
+  seq: 4
+}

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -15,6 +15,8 @@ security:
   - cookieAuth: []
 
 tags:
+  - name: Admin
+    description: Administrative operations (requires admin privileges)
   - name: Gameplay
     description: Game submission and grading
   - name: Users
@@ -59,6 +61,57 @@ paths:
           $ref: "#/components/responses/BadRequest"
         "404":
           $ref: "#/components/responses/NotFound"
+
+  /puzzle:
+    put:
+      summary: Set puzzle answer (admin-only)
+      description: |
+        Set the answer for a puzzle on a specific date.
+
+        This endpoint is restricted to administrators. Only users whose Auth0
+        subject is in the ADMIN_USER_IDS environment variable can access this endpoint.
+      operationId: setPuzzle
+      tags:
+        - Admin
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SetPuzzleRequest"
+            examples:
+              default:
+                value:
+                  date: "2026-02-15"
+                  word: "crane"
+              withTeam:
+                value:
+                  date: "2026-02-15"
+                  word: "crane"
+                  teamId: "team-123"
+      responses:
+        "200":
+          description: Puzzle answer set successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SetPuzzleResponse"
+              examples:
+                default:
+                  value:
+                    date: "2026-02-15"
+                    word: "crane"
+                withTeam:
+                  value:
+                    date: "2026-02-15"
+                    word: "crane"
+                    teamId: "team-123"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
 
   /profile:
     get:
@@ -851,6 +904,47 @@ components:
           format: uri
           description: URL to the uploaded avatar image
           example: "https://bucket.s3.amazonaws.com/avatars/auth0-123/1234567890.jpg"
+
+    SetPuzzleRequest:
+      type: object
+      required:
+        - date
+        - word
+      properties:
+        date:
+          type: string
+          format: date
+          description: The date of the puzzle in ISO format (YYYY-MM-DD)
+          example: "2026-02-15"
+        word:
+          type: string
+          pattern: "^[a-zA-Z]{5}$"
+          description: The 5-letter answer word
+          example: "crane"
+        teamId:
+          type: string
+          description: Optional team ID for team-specific puzzles
+          example: "team-123"
+
+    SetPuzzleResponse:
+      type: object
+      required:
+        - date
+        - word
+      properties:
+        date:
+          type: string
+          format: date
+          description: The date of the puzzle
+          example: "2026-02-15"
+        word:
+          type: string
+          description: The answer word (lowercase)
+          example: "crane"
+        teamId:
+          type: string
+          description: Team ID if set
+          example: "team-123"
 
     ErrorResponse:
       type: object

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,6 +33,8 @@ pub struct Config {
     pub cors_allowed_origins: Vec<String>,
     /// S3 bucket name for avatar uploads.
     pub s3_avatar_bucket: Option<String>,
+    /// Comma-separated list of admin user IDs (Auth0 subjects).
+    pub admin_user_ids: Vec<String>,
 }
 
 impl Default for Config {
@@ -57,6 +59,7 @@ impl Default for Config {
                 "https://wordles.dev".to_string(),
             ],
             s3_avatar_bucket: None,
+            admin_user_ids: Vec::new(),
         }
     }
 }
@@ -95,6 +98,14 @@ impl Config {
                 .map(|s| s.split(',').map(|s| s.trim().to_string()).collect())
                 .unwrap_or(default_origins),
             s3_avatar_bucket: std::env::var("S3_AVATAR_BUCKET").ok(),
+            admin_user_ids: std::env::var("ADMIN_USER_IDS")
+                .map(|s| {
+                    s.split(',')
+                        .map(|s| s.trim().to_string())
+                        .filter(|s| !s.is_empty())
+                        .collect()
+                })
+                .unwrap_or_default(),
         }
     }
 
@@ -157,6 +168,16 @@ impl Config {
     pub fn s3_avatar_bucket(&self) -> Option<&str> {
         self.s3_avatar_bucket.as_deref()
     }
+
+    /// Returns the list of admin user IDs.
+    pub fn admin_user_ids(&self) -> &[String] {
+        &self.admin_user_ids
+    }
+
+    /// Checks if a user ID is an admin.
+    pub fn is_admin(&self, user_id: &str) -> bool {
+        self.admin_user_ids.iter().any(|id| id == user_id)
+    }
 }
 
 #[cfg(test)]
@@ -192,5 +213,17 @@ mod tests {
             .cors_allowed_origins
             .contains(&"https://wordles.dev".to_string()));
         assert!(config.s3_avatar_bucket.is_none());
+        assert!(config.admin_user_ids.is_empty());
+    }
+
+    #[test]
+    fn test_is_admin() {
+        let mut config = Config::default();
+        config.admin_user_ids = vec!["auth0|admin1".to_string(), "auth0|admin2".to_string()];
+
+        assert!(config.is_admin("auth0|admin1"));
+        assert!(config.is_admin("auth0|admin2"));
+        assert!(!config.is_admin("auth0|user1"));
+        assert!(!config.is_admin(""));
     }
 }

--- a/src/db/puzzle.rs
+++ b/src/db/puzzle.rs
@@ -32,6 +32,14 @@ pub trait PuzzleDatabase: Send + Sync {
 
     /// Gets the puzzle answer for a specific date.
     async fn get_puzzle_answer(&self, puzzle_date: NaiveDate) -> DatabaseResult<Option<String>>;
+
+    /// Sets the puzzle answer for a specific date.
+    async fn set_puzzle_answer(
+        &self,
+        puzzle_date: NaiveDate,
+        word: &str,
+        team_id: Option<&str>,
+    ) -> DatabaseResult<()>;
 }
 
 /// DynamoDB implementation of puzzle database.
@@ -219,6 +227,44 @@ impl PuzzleDatabase for DynamoDbPuzzleRepository {
 
         Ok(answer)
     }
+
+    async fn set_puzzle_answer(
+        &self,
+        puzzle_date: NaiveDate,
+        word: &str,
+        team_id: Option<&str>,
+    ) -> DatabaseResult<()> {
+        let pk = PuzzleAnswer::pk(puzzle_date);
+        let sk = PuzzleAnswer::sk();
+
+        let mut item = HashMap::new();
+        item.insert("pk".to_string(), AttributeValue::S(pk));
+        item.insert("sk".to_string(), AttributeValue::S(sk.to_string()));
+        item.insert("word".to_string(), AttributeValue::S(word.to_string()));
+        item.insert(
+            "puzzle_date".to_string(),
+            AttributeValue::S(puzzle_date.to_string()),
+        );
+
+        if let Some(tid) = team_id {
+            item.insert("team_id".to_string(), AttributeValue::S(tid.to_string()));
+        }
+
+        self.client
+            .put_item()
+            .table_name(&self.table_name)
+            .set_item(Some(item))
+            .send()
+            .await
+            .map_err(|e| DatabaseError::Other(format!("DynamoDB put error: {}", e)))?;
+
+        // Invalidate cache for this date
+        if let Ok(mut cache) = ANSWER_CACHE.write() {
+            cache.insert(puzzle_date, word.to_string());
+        }
+
+        Ok(())
+    }
 }
 
 /// In-memory puzzle database for testing.
@@ -281,6 +327,20 @@ impl PuzzleDatabase for InMemoryPuzzleDb {
             .read()
             .map_err(|e| DatabaseError::LockError(e.to_string()))?;
         Ok(answers.get(&puzzle_date).cloned())
+    }
+
+    async fn set_puzzle_answer(
+        &self,
+        puzzle_date: NaiveDate,
+        word: &str,
+        _team_id: Option<&str>,
+    ) -> DatabaseResult<()> {
+        let mut answers = self
+            .puzzle_answers
+            .write()
+            .map_err(|e| DatabaseError::LockError(e.to_string()))?;
+        answers.insert(puzzle_date, word.to_string());
+        Ok(())
     }
 }
 
@@ -372,5 +432,30 @@ mod tests {
         let retrieved = db.get_game_state("user1", date).await.unwrap().unwrap();
         assert_eq!(retrieved.guesses.len(), 2);
         assert!(retrieved.won);
+    }
+
+    #[tokio::test]
+    async fn test_inmemory_set_puzzle_answer() {
+        let db = InMemoryPuzzleDb::new();
+        let date = NaiveDate::from_ymd_opt(2026, 2, 15).unwrap();
+
+        // No answer initially
+        let answer = db.get_puzzle_answer(date).await.unwrap();
+        assert!(answer.is_none());
+
+        // Set answer
+        db.set_puzzle_answer(date, "crane", None).await.unwrap();
+
+        // Retrieve answer
+        let answer = db.get_puzzle_answer(date).await.unwrap();
+        assert_eq!(answer, Some("crane".to_string()));
+
+        // Update answer
+        db.set_puzzle_answer(date, "slate", Some("team-123"))
+            .await
+            .unwrap();
+
+        let answer = db.get_puzzle_answer(date).await.unwrap();
+        assert_eq!(answer, Some("slate".to_string()));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,8 +24,8 @@ use db::{
 };
 use middleware::auth::JwtAuth;
 use routes::{
-    create_games, get_games, get_profile, health_check, list_games, submit_guess, update_profile,
-    upload_avatar,
+    create_games, get_games, get_profile, health_check, list_games, set_puzzle, submit_guess,
+    update_profile, upload_avatar,
 };
 use services::{Auth0ManagementService, S3AvatarService};
 
@@ -195,7 +195,8 @@ async fn main() -> std::io::Result<()> {
             .service(list_games)
             .service(get_games)
             .service(create_games)
-            .service(submit_guess);
+            .service(submit_guess)
+            .service(set_puzzle);
 
         // Only register profile endpoints if Auth0 M2M is configured
         if let Some(ref auth0) = auth0_service {

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -4,8 +4,10 @@ pub mod games;
 pub mod guess;
 pub mod health;
 pub mod profile;
+pub mod puzzle;
 
 pub use games::{create_games, get_games, list_games};
 pub use guess::submit_guess;
 pub use health::*;
 pub use profile::{get_profile, update_profile, upload_avatar};
+pub use puzzle::set_puzzle;

--- a/src/routes/puzzle.rs
+++ b/src/routes/puzzle.rs
@@ -1,0 +1,126 @@
+//! Route handler for puzzle management (admin-only).
+
+use actix_web::{put, web, HttpResponse};
+use chrono::NaiveDate;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+use crate::config::Config;
+use crate::db::PuzzleDatabase;
+use crate::middleware::auth::Claims;
+use crate::models::error::AppError;
+
+/// Request payload for setting a puzzle answer.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SetPuzzleRequest {
+    /// The date of the puzzle in ISO format (YYYY-MM-DD).
+    pub date: NaiveDate,
+    /// The 5-letter answer word.
+    pub word: String,
+    /// Optional team ID for team-specific puzzles.
+    #[serde(rename = "teamId")]
+    pub team_id: Option<String>,
+}
+
+/// Response for setting a puzzle answer.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SetPuzzleResponse {
+    /// The date of the puzzle.
+    pub date: NaiveDate,
+    /// The answer word.
+    pub word: String,
+    /// Optional team ID if set.
+    #[serde(rename = "teamId", skip_serializing_if = "Option::is_none")]
+    pub team_id: Option<String>,
+}
+
+/// PUT /puzzle - Set the answer for a puzzle (admin-only).
+///
+/// This endpoint allows administrators to set or update the puzzle answer
+/// for a specific date. Only users whose Auth0 subject is in the
+/// ADMIN_USER_IDS environment variable can access this endpoint.
+#[put("/puzzle")]
+pub async fn set_puzzle(
+    claims: Claims,
+    body: web::Json<SetPuzzleRequest>,
+    puzzle_db: web::Data<Arc<dyn PuzzleDatabase>>,
+    config: web::Data<Config>,
+) -> Result<HttpResponse, AppError> {
+    // Check if user is an admin
+    if !config.is_admin(&claims.sub) {
+        return Err(AppError::Forbidden(
+            "Only administrators can set puzzle answers".to_string(),
+        ));
+    }
+
+    let word = body.word.to_lowercase();
+
+    // Validate word is exactly 5 lowercase letters
+    if word.len() != 5 {
+        return Err(AppError::bad_request("Word must be exactly 5 letters"));
+    }
+
+    if !word.chars().all(|c| c.is_ascii_lowercase()) {
+        return Err(AppError::bad_request(
+            "Word must contain only letters (a-z)",
+        ));
+    }
+
+    // Set the puzzle answer
+    puzzle_db
+        .set_puzzle_answer(body.date, &word, body.team_id.as_deref())
+        .await
+        .map_err(|e| AppError::InternalError(format!("Database error: {}", e)))?;
+
+    Ok(HttpResponse::Ok().json(SetPuzzleResponse {
+        date: body.date,
+        word,
+        team_id: body.team_id.clone(),
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_set_puzzle_request_parsing() {
+        let json = r#"{"date": "2026-02-15", "word": "crane"}"#;
+        let req: SetPuzzleRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.date, NaiveDate::from_ymd_opt(2026, 2, 15).unwrap());
+        assert_eq!(req.word, "crane");
+        assert!(req.team_id.is_none());
+    }
+
+    #[test]
+    fn test_set_puzzle_request_with_team_id() {
+        let json = r#"{"date": "2026-02-15", "word": "crane", "teamId": "team-123"}"#;
+        let req: SetPuzzleRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.team_id, Some("team-123".to_string()));
+    }
+
+    #[test]
+    fn test_set_puzzle_response_serialization() {
+        let response = SetPuzzleResponse {
+            date: NaiveDate::from_ymd_opt(2026, 2, 15).unwrap(),
+            word: "crane".to_string(),
+            team_id: None,
+        };
+        let json = serde_json::to_string(&response).unwrap();
+        assert!(json.contains("2026-02-15"));
+        assert!(json.contains("crane"));
+        assert!(!json.contains("teamId")); // should be skipped when None
+    }
+
+    #[test]
+    fn test_set_puzzle_response_with_team_id() {
+        let response = SetPuzzleResponse {
+            date: NaiveDate::from_ymd_opt(2026, 2, 15).unwrap(),
+            word: "crane".to_string(),
+            team_id: Some("team-123".to_string()),
+        };
+        let json = serde_json::to_string(&response).unwrap();
+        assert!(json.contains("teamId"));
+        assert!(json.contains("team-123"));
+    }
+}


### PR DESCRIPTION
## Summary
- Add new admin-only endpoint `PUT /puzzle` for setting puzzle answers via API
- Only users whose Auth0 subject is in `ADMIN_USER_IDS` env var can access
- Includes OpenAPI documentation and Bruno request

## Changes
- **src/config.rs**: Add `admin_user_ids` field parsed from `ADMIN_USER_IDS` env var
- **src/db/puzzle.rs**: Add `set_puzzle_answer` to `PuzzleDatabase` trait with DynamoDB and in-memory implementations
- **src/routes/puzzle.rs**: New route handler with word validation (5 lowercase letters)
- **src/routes/mod.rs**: Export new puzzle module
- **src/main.rs**: Register set_puzzle route
- **docs/openapi/openapi.yaml**: Add Admin tag and SetPuzzle schemas
- **docs/bruno/Admin/**: New folder with Set Puzzle request
- **docker-compose.yml**: Add `ADMIN_USER_IDS` env var

## Test plan
- [x] Unit tests pass (100 tests)
- [x] Clippy clean
- [ ] Manual testing with docker-compose:
  ```bash
  export ADMIN_USER_IDS="auth0|your-user-id"
  docker-compose up --build -d

  # Test success (as admin)
  curl -X PUT http://localhost:8080/puzzle \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $JWT" \
    -d '{"date":"2026-02-15","word":"crane"}'

  # Test 403 (non-admin)
  # Use JWT for user not in ADMIN_USER_IDS

  # Test 400 (invalid word)
  curl -X PUT http://localhost:8080/puzzle \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $JWT" \
    -d '{"date":"2026-02-15","word":"hi"}'
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)