### PR TITLE
feat: Add GET /history endpoint for user game history

### DIFF
--- a/docs/bruno/History/Get History.bru
+++ b/docs/bruno/History/Get History.bru
@@ -1,0 +1,44 @@
+meta {
+  name: Get History
+  type: http
+  seq: 1
+}
+
+get {
+  url: https://{{baseUrl}}/history
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{jwt}}
+}
+
+docs {
+  Retrieves the game history for the currently authenticated user.
+
+  ## Authentication
+  Requires a valid Bearer token.
+
+  ## Responses
+  - `200`: History retrieved successfully
+    ```json
+    {
+      "user_id": "auth0|123456",
+      "total_games": 5,
+      "games_won": 3,
+      "games": [
+        {
+          "game_id": "550e8400-e29b-41d4-a716-446655440000",
+          "puzzle_date": "2026-01-15",
+          "guesses_count": 4,
+          "won": true,
+          "in_progress": false,
+          "created_at": "2026-01-15T10:00:00Z",
+          "updated_at": "2026-01-15T10:05:00Z"
+        }
+      ]
+    }
+    ```
+  - `401`: Authentication required or invalid token
+}

--- a/docs/bruno/History/folder.bru
+++ b/docs/bruno/History/folder.bru
@@ -1,0 +1,4 @@
+meta {
+  name: History
+  seq: 4
+}

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -62,6 +62,48 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
 
+  /history:
+    get:
+      summary: Get user's game history
+      description: |
+        Retrieve all games played by the authenticated user.
+
+        Returns games sorted by puzzle date (most recent first), along with
+        aggregate statistics like total games played and games won.
+      operationId: getHistory
+      tags:
+        - Gameplay
+      responses:
+        "200":
+          description: Game history retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HistoryResponse"
+              examples:
+                default:
+                  value:
+                    user_id: "auth0|123456789"
+                    total_games: 5
+                    games_won: 3
+                    games:
+                      - game_id: "550e8400-e29b-41d4-a716-446655440000"
+                        puzzle_date: "2026-01-15"
+                        guesses_count: 4
+                        won: true
+                        in_progress: false
+                        created_at: "2026-01-15T10:00:00Z"
+                        updated_at: "2026-01-15T10:05:00Z"
+                      - game_id: "550e8400-e29b-41d4-a716-446655440001"
+                        puzzle_date: "2026-01-14"
+                        guesses_count: 6
+                        won: false
+                        in_progress: false
+                        created_at: "2026-01-14T09:00:00Z"
+                        updated_at: "2026-01-14T09:10:00Z"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
   /puzzle:
     put:
       summary: Set puzzle answer (admin-only)
@@ -945,6 +987,68 @@ components:
           type: string
           description: Team ID if set
           example: "team-123"
+
+    HistoryGame:
+      type: object
+      required:
+        - game_id
+        - puzzle_date
+        - guesses_count
+        - won
+        - in_progress
+        - created_at
+        - updated_at
+      properties:
+        game_id:
+          type: string
+          format: uuid
+          description: Unique identifier for this game
+        puzzle_date:
+          type: string
+          format: date
+          description: The puzzle date (YYYY-MM-DD)
+        guesses_count:
+          type: integer
+          minimum: 0
+          maximum: 6
+          description: Number of guesses made
+        won:
+          type: boolean
+          description: Whether the player won
+        in_progress:
+          type: boolean
+          description: Whether the game is still in progress
+        created_at:
+          type: string
+          format: date-time
+          description: When the game was started
+        updated_at:
+          type: string
+          format: date-time
+          description: When the game was last updated
+
+    HistoryResponse:
+      type: object
+      required:
+        - user_id
+        - total_games
+        - games_won
+        - games
+      properties:
+        user_id:
+          type: string
+          description: The authenticated user's ID
+        total_games:
+          type: integer
+          description: Total number of games played
+        games_won:
+          type: integer
+          description: Number of games won
+        games:
+          type: array
+          description: List of games sorted by puzzle date (most recent first)
+          items:
+            $ref: "#/components/schemas/HistoryGame"
 
     ErrorResponse:
       type: object

--- a/src/db/puzzle.rs
+++ b/src/db/puzzle.rs
@@ -27,6 +27,9 @@ pub trait PuzzleDatabase: Send + Sync {
         puzzle_date: NaiveDate,
     ) -> DatabaseResult<Option<GameState>>;
 
+    /// Gets all game states for a user.
+    async fn get_user_game_states(&self, user_id: &str) -> DatabaseResult<Vec<GameState>>;
+
     /// Creates or updates a game state.
     async fn upsert_game_state(&self, game_state: &GameState) -> DatabaseResult<GameState>;
 
@@ -175,6 +178,36 @@ impl PuzzleDatabase for DynamoDbPuzzleRepository {
         }
     }
 
+    async fn get_user_game_states(&self, user_id: &str) -> DatabaseResult<Vec<GameState>> {
+        // Query using a begins_with on pk to find all USER#{user_id}#PUZZLE# entries
+        // Since DynamoDB partition key is the full pk, we need to use a scan with filter
+        // or create a GSI. For now, we'll use a scan with filter expression.
+        let pk_prefix = format!("USER#{}#PUZZLE#", user_id);
+
+        let result = self
+            .client
+            .scan()
+            .table_name(&self.table_name)
+            .filter_expression("begins_with(pk, :pk_prefix) AND sk = :sk")
+            .expression_attribute_values(":pk_prefix", AttributeValue::S(pk_prefix))
+            .expression_attribute_values(":sk", AttributeValue::S(GameState::sk().to_string()))
+            .send()
+            .await
+            .map_err(|e| DatabaseError::Other(format!("DynamoDB scan error: {}", e)))?;
+
+        let mut game_states = Vec::new();
+        if let Some(items) = result.items {
+            for item in items {
+                game_states.push(Self::item_to_game_state(&item)?);
+            }
+        }
+
+        // Sort by puzzle_date descending (most recent first)
+        game_states.sort_by(|a, b| b.puzzle_date.cmp(&a.puzzle_date));
+
+        Ok(game_states)
+    }
+
     async fn upsert_game_state(&self, game_state: &GameState) -> DatabaseResult<GameState> {
         let item = Self::game_state_to_item(game_state);
 
@@ -309,6 +342,24 @@ impl PuzzleDatabase for InMemoryPuzzleDb {
             .read()
             .map_err(|e| DatabaseError::LockError(e.to_string()))?;
         Ok(states.get(&key).cloned())
+    }
+
+    async fn get_user_game_states(&self, user_id: &str) -> DatabaseResult<Vec<GameState>> {
+        let states = self
+            .game_states
+            .read()
+            .map_err(|e| DatabaseError::LockError(e.to_string()))?;
+
+        let mut user_states: Vec<GameState> = states
+            .values()
+            .filter(|s| s.user_id == user_id)
+            .cloned()
+            .collect();
+
+        // Sort by puzzle_date descending (most recent first)
+        user_states.sort_by(|a, b| b.puzzle_date.cmp(&a.puzzle_date));
+
+        Ok(user_states)
     }
 
     async fn upsert_game_state(&self, game_state: &GameState) -> DatabaseResult<GameState> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,8 +24,8 @@ use db::{
 };
 use middleware::auth::JwtAuth;
 use routes::{
-    create_games, get_games, get_profile, health_check, list_games, set_puzzle, submit_guess,
-    update_profile, upload_avatar,
+    create_games, get_games, get_history, get_profile, health_check, list_games, set_puzzle,
+    submit_guess, update_profile, upload_avatar,
 };
 use services::{Auth0ManagementService, S3AvatarService};
 
@@ -196,7 +196,8 @@ async fn main() -> std::io::Result<()> {
             .service(get_games)
             .service(create_games)
             .service(submit_guess)
-            .service(set_puzzle);
+            .service(set_puzzle)
+            .service(get_history);
 
         // Only register profile endpoints if Auth0 M2M is configured
         if let Some(ref auth0) = auth0_service {

--- a/src/routes/history.rs
+++ b/src/routes/history.rs
@@ -1,0 +1,140 @@
+//! Route handler for game history.
+
+use actix_web::{get, web, HttpResponse};
+use chrono::NaiveDate;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use uuid::Uuid;
+
+use crate::db::PuzzleDatabase;
+use crate::middleware::auth::Claims;
+use crate::models::error::AppError;
+
+/// Response for a single game in history.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HistoryGame {
+    /// Unique identifier for this game (deterministic based on user_id and puzzle_date).
+    pub game_id: Uuid,
+    /// The puzzle date (YYYY-MM-DD).
+    pub puzzle_date: NaiveDate,
+    /// Number of guesses made (1-6).
+    pub guesses_count: usize,
+    /// Whether the player won.
+    pub won: bool,
+    /// Whether the game is still in progress.
+    pub in_progress: bool,
+    /// When the game was started (ISO 8601).
+    pub created_at: String,
+    /// When the game was last updated (ISO 8601).
+    pub updated_at: String,
+}
+
+/// Response for the history endpoint.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HistoryResponse {
+    /// The user ID.
+    pub user_id: String,
+    /// Total number of games.
+    pub total_games: usize,
+    /// Number of games won.
+    pub games_won: usize,
+    /// The list of games.
+    pub games: Vec<HistoryGame>,
+}
+
+/// GET /history - Get the authenticated user's game history.
+///
+/// Returns all games played by the user, sorted by puzzle date (most recent first).
+#[get("/history")]
+pub async fn get_history(
+    claims: Claims,
+    puzzle_db: web::Data<Arc<dyn PuzzleDatabase>>,
+) -> Result<HttpResponse, AppError> {
+    let user_id = claims.sub;
+
+    let game_states = puzzle_db
+        .get_user_game_states(&user_id)
+        .await
+        .map_err(|e| AppError::InternalError(format!("Database error: {}", e)))?;
+
+    let games: Vec<HistoryGame> = game_states
+        .iter()
+        .map(|state| {
+            // Generate deterministic game_id based on user_id and puzzle_date
+            let game_id = Uuid::new_v5(
+                &Uuid::NAMESPACE_OID,
+                format!("{}#{}", state.user_id, state.puzzle_date).as_bytes(),
+            );
+
+            HistoryGame {
+                game_id,
+                puzzle_date: state.puzzle_date,
+                guesses_count: state.guesses.len(),
+                won: state.won,
+                in_progress: state.is_in_progress(),
+                created_at: state.created_at.to_rfc3339(),
+                updated_at: state.updated_at.to_rfc3339(),
+            }
+        })
+        .collect();
+
+    let games_won = games.iter().filter(|g| g.won).count();
+
+    let response = HistoryResponse {
+        user_id,
+        total_games: games.len(),
+        games_won,
+        games,
+    };
+
+    Ok(HttpResponse::Ok().json(response))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_history_game_serialization() {
+        let game = HistoryGame {
+            game_id: Uuid::new_v4(),
+            puzzle_date: NaiveDate::from_ymd_opt(2026, 1, 15).unwrap(),
+            guesses_count: 3,
+            won: true,
+            in_progress: false,
+            created_at: "2026-01-15T10:00:00Z".to_string(),
+            updated_at: "2026-01-15T10:05:00Z".to_string(),
+        };
+
+        let json = serde_json::to_string(&game).unwrap();
+        assert!(json.contains("game_id"));
+        assert!(json.contains("puzzle_date"));
+        assert!(json.contains("guesses_count"));
+        assert!(json.contains("won"));
+        assert!(json.contains("in_progress"));
+    }
+
+    #[test]
+    fn test_history_response_serialization() {
+        let response = HistoryResponse {
+            user_id: "auth0|123".to_string(),
+            total_games: 1,
+            games_won: 1,
+            games: vec![HistoryGame {
+                game_id: Uuid::new_v4(),
+                puzzle_date: NaiveDate::from_ymd_opt(2026, 1, 15).unwrap(),
+                guesses_count: 3,
+                won: true,
+                in_progress: false,
+                created_at: "2026-01-15T10:00:00Z".to_string(),
+                updated_at: "2026-01-15T10:05:00Z".to_string(),
+            }],
+        };
+
+        let json = serde_json::to_string(&response).unwrap();
+        assert!(json.contains("user_id"));
+        assert!(json.contains("total_games"));
+        assert!(json.contains("games_won"));
+        assert!(json.contains("games"));
+    }
+}

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -3,11 +3,13 @@
 pub mod games;
 pub mod guess;
 pub mod health;
+pub mod history;
 pub mod profile;
 pub mod puzzle;
 
 pub use games::{create_games, get_games, list_games};
 pub use guess::submit_guess;
 pub use health::*;
+pub use history::get_history;
 pub use profile::{get_profile, update_profile, upload_avatar};
 pub use puzzle::set_puzzle;


### PR DESCRIPTION
## Summary
- Add new authenticated `/history` endpoint that returns all games played by the user
- Games are sorted by puzzle date (most recent first)
- Response includes aggregate statistics (total games, games won)
- Each game includes metadata: game_id, puzzle_date, guesses_count, won status, in_progress status, timestamps

## Changes
- Added `get_user_game_states()` method to `PuzzleDatabase` trait
- Implemented for both `InMemoryPuzzleDb` (testing) and `DynamoDbPuzzleRepository` (production)
- Created history route handler with proper JWT authentication
- Added OpenAPI documentation for the new endpoint
- Added Bruno collection for API testing

## Test plan
- [x] Unit tests for response serialization
- [x] Tested locally with docker-compose
- [x] Verified with multiple games (different dates, won/lost/in-progress states)
- [x] Confirmed correct sorting (most recent first)
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)