### PR TITLE
Restore Swagger UI for API docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -66,15 +66,13 @@ jobs:
         run: |
           mkdir -p docs-site/planned
 
-          # Build current API docs
-          redocly build-docs docs/openapi/openapi.yaml -o docs-site/index.html
-
-          # Build planned API docs
-          redocly build-docs docs/openapi/openapi-planned.yaml -o docs-site/planned/index.html
-
-          # Bundle specs for download
+          # Bundle specs
           redocly bundle docs/openapi/openapi.yaml -o docs-site/openapi-bundled.yaml
-          redocly bundle docs/openapi/openapi-planned.yaml -o docs-site/planned/openapi-planned-bundled.yaml
+          redocly bundle docs/openapi/openapi-planned.yaml -o docs-site/planned/openapi-bundled.yaml
+
+          # Copy Swagger UI pages
+          cp docs/openapi/index.html docs-site/index.html
+          cp docs/openapi/index-planned.html docs-site/planned/index.html
 
       - name: Setup Pages
         uses: actions/configure-pages@v4

--- a/docs/openapi/index-planned.html
+++ b/docs/openapi/index-planned.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Scorekeeper API Documentation (Planned)</title>
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css">
+  </head>
+  <body>
+    <div id="swagger-ui"></div>
+    <script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js"></script>
+    <script>
+      SwaggerUIBundle({
+        url: './openapi-bundled.yaml',
+        dom_id: '#swagger-ui',
+        presets: [SwaggerUIBundle.presets.apis],
+        layout: 'BaseLayout'
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Restores Swagger UI instead of Redocly HTML docs
- Keeps the `/` and `/planned/` routes with Swagger UI
- Bundles specs with redocly for `$ref` resolution

## Changes
- Updated GHA workflow to copy Swagger UI index.html instead of using `redocly build-docs`
- Added `index-planned.html` for the planned features page

## Test plan
- [ ] Verify Swagger UI loads at root URL after deploy
- [ ] Verify `/planned/` shows planned features with Swagger UI
- [ ] Verify examples render correctly in Swagger UI

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>