### PR TITLE
fix: Change /puzzle to /puzzles and add /puzzles/{date} endpoint

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -80,7 +80,7 @@ paths:
         "401":
           $ref: "#/components/responses/Unauthorized"
 
-  /puzzle:
+  /puzzles:
     get:
       summary: Get puzzle answers (game admin only)
       description: |
@@ -172,6 +172,42 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
+
+  /puzzles/{date}:
+    get:
+      summary: Get a single puzzle answer by date (game admin only)
+      description: |
+        Retrieve a single puzzle answer for a specific date.
+
+        Only users with app_metadata.game_admin = true can access this endpoint.
+      operationId: getPuzzleByDate
+      tags:
+        - Admin
+      parameters:
+        - name: date
+          in: path
+          required: true
+          schema:
+            type: string
+            format: date
+          description: The puzzle date (YYYY-MM-DD)
+          example: "2026-01-15"
+      responses:
+        "200":
+          description: Puzzle answer retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: "schemas.yaml#/PuzzleAnswerResponse"
+              example:
+                date: "2026-01-15"
+                word: "crane"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
 
   /profile:
     get:

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,8 +24,8 @@ use db::{
 };
 use middleware::auth::JwtAuth;
 use routes::{
-    create_games, get_game, get_games, get_history, get_profile, get_puzzles, health_check,
-    list_games, set_puzzle, submit_guess, update_profile, upload_avatar,
+    create_games, get_game, get_games, get_history, get_profile, get_puzzle_by_date, get_puzzles,
+    health_check, list_games, set_puzzle, submit_guess, update_profile, upload_avatar,
 };
 use services::{Auth0ManagementService, S3AvatarService};
 
@@ -197,6 +197,7 @@ async fn main() -> std::io::Result<()> {
             .service(get_game)
             .service(create_games)
             .service(submit_guess)
+            .service(get_puzzle_by_date)
             .service(get_puzzles)
             .service(set_puzzle)
             .service(get_history);

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -14,4 +14,4 @@ pub use guess::submit_guess;
 pub use health::*;
 pub use history::get_history;
 pub use profile::{get_profile, update_profile, upload_avatar};
-pub use puzzle::{get_puzzles, set_puzzle};
+pub use puzzle::{get_puzzle_by_date, get_puzzles, set_puzzle};

--- a/src/routes/puzzle.rs
+++ b/src/routes/puzzle.rs
@@ -62,14 +62,50 @@ pub struct GetPuzzlesResponse {
     pub puzzles: Vec<PuzzleAnswerResponse>,
 }
 
-/// GET /puzzle - Get puzzle answers (game admin only).
+/// GET /puzzles/{date} - Get a single puzzle answer by date (game admin only).
+///
+/// This endpoint allows game administrators to retrieve a single puzzle answer
+/// for a specific date. Only users with app_metadata.game_admin = true can access
+/// this endpoint.
+#[get("/puzzles/{date}")]
+pub async fn get_puzzle_by_date(
+    claims: Claims,
+    path: web::Path<NaiveDate>,
+    puzzle_db: web::Data<Arc<dyn PuzzleDatabase>>,
+) -> Result<HttpResponse, AppError> {
+    // Check if user is a game admin
+    if !claims.is_game_admin() {
+        return Err(AppError::Forbidden(
+            "Only game administrators can view puzzle answers".to_string(),
+        ));
+    }
+
+    let date = path.into_inner();
+    let answer = puzzle_db
+        .get_puzzle_answer(date)
+        .await
+        .map_err(|e| AppError::InternalError(format!("Database error: {}", e)))?;
+
+    match answer {
+        Some(word) => Ok(HttpResponse::Ok().json(PuzzleAnswerResponse {
+            date,
+            word: Some(word),
+        })),
+        None => Err(AppError::not_found(format!(
+            "No puzzle found for date {}",
+            date
+        ))),
+    }
+}
+
+/// GET /puzzles - Get puzzle answers (game admin only).
 ///
 /// This endpoint allows game administrators to retrieve puzzle answers.
 /// With no query parameters, returns all puzzles. Use start_date and end_date
 /// to filter by date range. Use omit_answers=true to only return dates without
 /// the answer words. Only users with app_metadata.game_admin = true can access
 /// this endpoint.
-#[get("/puzzle")]
+#[get("/puzzles")]
 pub async fn get_puzzles(
     claims: Claims,
     query: web::Query<GetPuzzlesQuery>,
@@ -101,12 +137,12 @@ pub async fn get_puzzles(
     Ok(HttpResponse::Ok().json(response))
 }
 
-/// PUT /puzzle - Set the answer for a puzzle (game admin only).
+/// PUT /puzzles - Set the answer for a puzzle (game admin only).
 ///
 /// This endpoint allows game administrators to set or update the puzzle answer
 /// for a specific date. Only users with app_metadata.game_admin = true
 /// can access this endpoint.
-#[put("/puzzle")]
+#[put("/puzzles")]
 pub async fn set_puzzle(
     claims: Claims,
     body: web::Json<SetPuzzleRequest>,


### PR DESCRIPTION
## Summary

- Fixes 404 error on gamemaker page caused by endpoint mismatch
- Frontend calls `/puzzles` (plural), API had `/puzzle` (singular)
- Added RESTful `/puzzles/{date}` endpoint for single puzzle lookup

## Changes

| Endpoint | Before | After |
|----------|--------|-------|
| List puzzles | `GET /puzzle` | `GET /puzzles` |
| Set puzzle | `PUT /puzzle` | `PUT /puzzles` |
| Get single puzzle | ❌ | `GET /puzzles/{date}` |

## Test plan

- [x] All 211 tests pass
- [ ] Verify gamemaker page loads without 404
- [ ] Test `GET /puzzles` returns puzzle list
- [ ] Test `GET /puzzles/2026-02-01` returns single puzzle
- [ ] Test `PUT /puzzles` sets puzzle answer

🤖 Generated with [Claude Code](https://claude.com/claude-code)