### PR TITLE
feat: Add set_random_unused_word option to PUT /puzzles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2636,6 +2636,7 @@ dependencies = [
  "once_cell",
  "phf",
  "phf_codegen",
+ "rand 0.8.5",
  "reqwest",
  "rustls 0.23.36",
  "rustls-pemfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ async-trait = "0.1"
 base64 = "0.22"
 urlencoding = "2"
 phf = "0.11"
+rand = "0.8"
 
 [build-dependencies]
 phf_codegen = "0.11"

--- a/build.rs
+++ b/build.rs
@@ -36,6 +36,21 @@ fn main() {
     write!(&mut file, "static VALID_WORDS: phf::Set<&'static str> = ").unwrap();
     writeln!(&mut file, "{};", set_builder.build()).unwrap();
 
+    // Also generate a static array for iteration
+    writeln!(
+        &mut file,
+        "\n/// All valid words as a static array for iteration."
+    )
+    .unwrap();
+    write!(&mut file, "static ALL_WORDS: [&str; {}] = [", words.len()).unwrap();
+    for (i, word) in words.iter().enumerate() {
+        if i > 0 {
+            write!(&mut file, ", ").unwrap();
+        }
+        write!(&mut file, "\"{}\"", word).unwrap();
+    }
+    writeln!(&mut file, "];").unwrap();
+
     // Rerun if words.txt changes
     println!("cargo:rerun-if-changed=data/words.txt");
 }

--- a/docs/openapi/data-examples/SetPuzzleRequestRandomWord.json
+++ b/docs/openapi/data-examples/SetPuzzleRequestRandomWord.json
@@ -1,0 +1,4 @@
+{
+  "date": "2026-02-15",
+  "set_random_unused_word": true
+}

--- a/docs/openapi/data-examples/examples.yaml
+++ b/docs/openapi/data-examples/examples.yaml
@@ -51,6 +51,11 @@ SetPuzzleRequestWithTeam:
   value:
     $ref: "./SetPuzzleRequestWithTeam.json"
 
+SetPuzzleRequestRandomWord:
+  summary: Set puzzle with random unused word
+  value:
+    $ref: "./SetPuzzleRequestRandomWord.json"
+
 SetPuzzleResponse:
   summary: Set puzzle response
   value:

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -152,6 +152,10 @@ paths:
         Set the answer for a puzzle on a specific date.
 
         Only users with app_metadata.game_admin = true can access this endpoint.
+
+        You can either provide a specific word, or set `set_random_unused_word: true`
+        to automatically select a random word from the dictionary that hasn't been
+        used in any puzzle yet.
       operationId: setPuzzle
       tags:
         - Admin
@@ -166,6 +170,8 @@ paths:
                 $ref: "data-examples/examples.yaml#/SetPuzzleRequest"
               withTeam:
                 $ref: "data-examples/examples.yaml#/SetPuzzleRequestWithTeam"
+              randomWord:
+                $ref: "data-examples/examples.yaml#/SetPuzzleRequestRandomWord"
       responses:
         "200":
           description: Puzzle answer set successfully

--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -458,7 +458,6 @@ SetPuzzleRequest:
   type: object
   required:
     - date
-    - word
   properties:
     date:
       type: string
@@ -468,12 +467,18 @@ SetPuzzleRequest:
     word:
       type: string
       pattern: "^[a-zA-Z]{5}$"
-      description: The 5-letter answer word
+      description: The 5-letter answer word. Required unless setRandomUnusedWord is true.
       example: "crane"
     teamId:
       type: string
       description: Optional team ID for team-specific puzzles
       example: "team-123"
+    set_random_unused_word:
+      type: boolean
+      default: false
+      description: |
+        If true, automatically select a random word from the dictionary that hasn't
+        been used in any puzzle yet. When this is true, the word field is not required.
 
 SetPuzzleResponse:
   type: object

--- a/src/dictionary.rs
+++ b/src/dictionary.rs
@@ -15,6 +15,11 @@ pub fn word_count() -> usize {
     VALID_WORDS.len()
 }
 
+/// Returns an iterator over all valid words in the dictionary.
+pub fn all_words() -> impl Iterator<Item = &'static str> {
+    ALL_WORDS.iter().copied()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/routes/puzzle.rs
+++ b/src/routes/puzzle.rs
@@ -5,10 +5,13 @@
 
 use actix_web::{get, put, web, HttpResponse};
 use chrono::NaiveDate;
+use rand::seq::IteratorRandom;
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use crate::db::PuzzleDatabase;
+use crate::dictionary;
 use crate::middleware::auth::Claims;
 use crate::middleware::validation::{deserialize_optional_date, validate_date_range};
 use crate::models::error::AppError;
@@ -18,11 +21,14 @@ use crate::models::error::AppError;
 pub struct SetPuzzleRequest {
     /// The date of the puzzle in ISO format (YYYY-MM-DD).
     pub date: NaiveDate,
-    /// The 5-letter answer word.
-    pub word: String,
+    /// The 5-letter answer word. Required unless set_random_unused_word is true.
+    pub word: Option<String>,
     /// Optional team ID for team-specific puzzles.
     #[serde(rename = "teamId")]
     pub team_id: Option<String>,
+    /// If true, automatically select a random word that hasn't been used yet.
+    #[serde(default)]
+    pub set_random_unused_word: bool,
 }
 
 /// Response for setting a puzzle answer.
@@ -153,6 +159,9 @@ pub async fn get_puzzles(
 /// This endpoint allows game administrators to set or update the puzzle answer
 /// for a specific date. Only users with app_metadata.game_admin = true
 /// can access this endpoint.
+///
+/// You can either provide a specific word, or set `setRandomUnusedWord: true`
+/// to automatically select a random word that hasn't been used in any puzzle yet.
 #[put("/puzzles")]
 pub async fn set_puzzle(
     claims: Claims,
@@ -166,7 +175,43 @@ pub async fn set_puzzle(
         ));
     }
 
-    let word = body.word.to_lowercase();
+    let word = if body.set_random_unused_word {
+        // Get all existing puzzle answers to find used words
+        let existing_puzzles = puzzle_db
+            .get_puzzle_answers(None, None)
+            .await
+            .map_err(|e| AppError::InternalError(format!("Database error: {}", e)))?;
+
+        let used_words: HashSet<String> = existing_puzzles
+            .into_iter()
+            .map(|p| p.word.to_lowercase())
+            .collect();
+
+        // Find a random unused word from the dictionary
+        let mut rng = rand::thread_rng();
+        let unused_word = dictionary::all_words()
+            .filter(|word| !used_words.contains(*word))
+            .choose(&mut rng);
+
+        match unused_word {
+            Some(word) => word.to_string(),
+            None => {
+                return Err(AppError::bad_request(
+                    "No unused words available in the dictionary",
+                ))
+            }
+        }
+    } else {
+        // Use the provided word
+        match &body.word {
+            Some(w) => w.to_lowercase(),
+            None => {
+                return Err(AppError::bad_request(
+                    "Either provide a word or set set_random_unused_word to true",
+                ))
+            }
+        }
+    };
 
     // Validate word is exactly 5 lowercase letters
     if word.len() != 5 {
@@ -201,8 +246,9 @@ mod tests {
         let json = r#"{"date": "2026-02-15", "word": "crane"}"#;
         let req: SetPuzzleRequest = serde_json::from_str(json).unwrap();
         assert_eq!(req.date, NaiveDate::from_ymd_opt(2026, 2, 15).unwrap());
-        assert_eq!(req.word, "crane");
+        assert_eq!(req.word, Some("crane".to_string()));
         assert!(req.team_id.is_none());
+        assert!(!req.set_random_unused_word);
     }
 
     #[test]
@@ -210,6 +256,15 @@ mod tests {
         let json = r#"{"date": "2026-02-15", "word": "crane", "teamId": "team-123"}"#;
         let req: SetPuzzleRequest = serde_json::from_str(json).unwrap();
         assert_eq!(req.team_id, Some("team-123".to_string()));
+    }
+
+    #[test]
+    fn test_set_puzzle_request_with_random_word() {
+        let json = r#"{"date": "2026-02-15", "set_random_unused_word": true}"#;
+        let req: SetPuzzleRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.date, NaiveDate::from_ymd_opt(2026, 2, 15).unwrap());
+        assert!(req.word.is_none());
+        assert!(req.set_random_unused_word);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds `set_random_unused_word` option to the `PUT /puzzles` endpoint
- When `true`, automatically selects a random word from the dictionary that hasn't been used in any puzzle yet
- Makes `word` field optional when using this feature
- Returns error if all dictionary words have been used

## Test plan
- [x] Unit tests pass for new request format parsing
- [x] All existing tests pass
- [x] OpenAPI documentation updated with new field and example

🤖 Generated with [Claude Code](https://claude.com/claude-code)