### PR TITLE
feat: Add endpoint to clear puzzle answer cache

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -24,8 +24,9 @@ use db::{
 };
 use middleware::auth::JwtAuth;
 use routes::{
-    create_games, get_game, get_games, get_history, get_profile, get_puzzle_by_date, get_puzzles,
-    health_check, list_games, set_puzzle, submit_guess, update_profile, upload_avatar,
+    clear_puzzle_cache, create_games, get_game, get_games, get_history, get_profile,
+    get_puzzle_by_date, get_puzzles, health_check, list_games, set_puzzle, submit_guess,
+    update_profile, upload_avatar,
 };
 use services::{Auth0ManagementService, S3AvatarService};
 
@@ -200,6 +201,7 @@ async fn main() -> std::io::Result<()> {
             .service(get_puzzle_by_date)
             .service(get_puzzles)
             .service(set_puzzle)
+            .service(clear_puzzle_cache)
             .service(get_history);
 
         // Only register profile endpoints if Auth0 M2M is configured

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -14,4 +14,4 @@ pub use guess::submit_guess;
 pub use health::*;
 pub use history::get_history;
 pub use profile::{get_profile, update_profile, upload_avatar};
-pub use puzzle::{get_puzzle_by_date, get_puzzles, set_puzzle};
+pub use puzzle::{clear_puzzle_cache, get_puzzle_by_date, get_puzzles, set_puzzle};

--- a/src/routes/puzzle.rs
+++ b/src/routes/puzzle.rs
@@ -1,18 +1,18 @@
 //! Route handler for puzzle management.
 //!
 //! GET endpoints are accessible to all authenticated users, but answers are only
-//! visible to game administrators. PUT endpoint remains admin-only.
+//! visible to game administrators. PUT and cache clear endpoints are admin-only.
 
-use actix_web::{get, put, web, HttpResponse};
+use actix_web::{get, post, put, web, HttpResponse};
 use chrono::NaiveDate;
 use rand::seq::IteratorRandom;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::sync::Arc;
 
-use crate::db::PuzzleDatabase;
-use crate::dictionary::is_valid_word;
+use crate::db::{clear_answer_cache, PuzzleDatabase};
 use crate::dictionary;
+use crate::dictionary::is_valid_word;
 use crate::middleware::auth::Claims;
 use crate::middleware::validation::{deserialize_optional_date, validate_date_range};
 use crate::models::error::AppError;
@@ -241,6 +241,30 @@ pub async fn set_puzzle(
         word,
         team_id: body.team_id.clone(),
     }))
+}
+
+/// POST /puzzles/cache/clear - Clear the puzzle answer cache (game admin only).
+///
+/// This endpoint allows game administrators to clear the in-memory cache of puzzle
+/// answers. This is useful when puzzle answers have been modified directly in the
+/// database (e.g., via AWS console) and the server needs to pick up the changes.
+///
+/// Note: Each server instance has its own cache, so in a load-balanced environment
+/// this endpoint should be called on each instance, or all instances should be restarted.
+#[post("/puzzles/cache/clear")]
+pub async fn clear_puzzle_cache(claims: Claims) -> Result<HttpResponse, AppError> {
+    // Check if user is a game admin
+    if !claims.is_game_admin() {
+        return Err(AppError::Forbidden(
+            "Only game administrators can clear the cache".to_string(),
+        ));
+    }
+
+    clear_answer_cache();
+
+    Ok(HttpResponse::Ok().json(serde_json::json!({
+        "message": "Puzzle answer cache cleared"
+    })))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Adds `POST /puzzles/cache/clear` endpoint for game administrators
- Allows clearing the in-memory puzzle answer cache when answers are modified directly in DynamoDB
- Fixes issue where stale cached answers cause inconsistent grading

## Problem
When puzzle answers are modified directly in DynamoDB (e.g., via AWS console), the server's in-memory cache (`ANSWER_CACHE`) retains the old values. This causes:
- Inconsistent grading if different server instances have different cached values
- Grading that doesn't match the current database values

## Solution
Add an admin-only endpoint that calls `clear_answer_cache()` to invalidate all cached puzzle answers. After calling this endpoint, subsequent requests will fetch fresh answers from DynamoDB.

## Usage
```bash
curl -X POST https://api.wordles.dev/puzzles/cache/clear \
  -H "Authorization: Bearer <admin-token>"
```

## Note
In a load-balanced environment, this endpoint should be called on each server instance, or all instances should be restarted after changing puzzle answers in DynamoDB.

## Test plan
- [x] Code compiles with `cargo check`
- [x] All 116 unit tests pass with `cargo test`
- [x] CDK tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)