### PR TITLE
DOCS: adds cache clear endpoint to OpenAPI and DynamoDB schema docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,77 @@ API backend for the Scorekeeper word puzzle game.
 ## Development
 
 See [AGENTS.md](./AGENTS.md) for development guidelines.
+
+## DynamoDB Schema
+
+The application uses a single-table design in DynamoDB with composite primary keys (partition key `pk` and sort key `sk`).
+
+### Table Structure
+
+| Entity | Partition Key (pk) | Sort Key (sk) | Attributes |
+|--------|-------------------|---------------|------------|
+| Game State | `USER#{user_id}#PUZZLE#{date}` | `GAME_STATE` | `user_id`, `puzzle_date`, `guesses[]`, `won`, `created_at`, `updated_at` |
+| Puzzle Answer | `PUZZLE#{date}` | `ANSWER` | `puzzle_date`, `word`, `team_id` (optional) |
+
+### Entity Details
+
+#### Game State
+Stores a user's progress on a specific puzzle.
+
+- **pk**: `USER#{user_id}#PUZZLE#{YYYY-MM-DD}` - Combines user identity with puzzle date
+- **sk**: `GAME_STATE` - Constant sort key for this entity type
+- **guesses**: Array of 5-letter words the user has guessed (lowercase)
+- **won**: Boolean indicating if the user solved the puzzle
+- **created_at**: ISO 8601 timestamp when the game was started
+- **updated_at**: ISO 8601 timestamp of the last guess
+
+Example:
+```json
+{
+  "pk": "USER#auth0|123456#PUZZLE#2026-02-02",
+  "sk": "GAME_STATE",
+  "user_id": "auth0|123456",
+  "puzzle_date": "2026-02-02",
+  "guesses": ["crane", "slate", "moist"],
+  "won": false,
+  "created_at": "2026-02-02T10:30:00Z",
+  "updated_at": "2026-02-02T10:35:00Z"
+}
+```
+
+#### Puzzle Answer
+Stores the answer word for a specific puzzle date.
+
+- **pk**: `PUZZLE#{YYYY-MM-DD}` - The puzzle date
+- **sk**: `ANSWER` - Constant sort key for this entity type
+- **word**: The 5-letter answer word (lowercase)
+- **team_id**: Optional team ID for team-specific puzzles
+
+Example:
+```json
+{
+  "pk": "PUZZLE#2026-02-02",
+  "sk": "ANSWER",
+  "puzzle_date": "2026-02-02",
+  "word": "manna",
+  "team_id": null
+}
+```
+
+### Access Patterns
+
+| Access Pattern | Operation | Key Condition |
+|----------------|-----------|---------------|
+| Get user's game for a puzzle | GetItem | `pk = USER#{user_id}#PUZZLE#{date}`, `sk = GAME_STATE` |
+| Get all games for a user | Scan + Filter | `begins_with(pk, USER#{user_id}#PUZZLE#)`, `sk = GAME_STATE` |
+| Get puzzle answer | GetItem | `pk = PUZZLE#{date}`, `sk = ANSWER` |
+| Get all puzzle answers | Scan + Filter | `begins_with(pk, PUZZLE#)`, `sk = ANSWER` |
+
+### Caching
+
+Puzzle answers are cached in-memory on each server instance to reduce DynamoDB reads. The cache:
+- Has no automatic TTL (entries persist until server restart)
+- Is updated when answers are set via the API (`PUT /puzzles`)
+- Can be manually cleared via `POST /puzzles/cache/clear` (admin only)
+
+**Important**: In a multi-instance deployment, each server has its own cache. If puzzle answers are modified directly in DynamoDB (not via the API), call the cache clear endpoint or restart all server instances to ensure consistent grading.

--- a/docs/openapi/data-examples/CacheClearResponse.json
+++ b/docs/openapi/data-examples/CacheClearResponse.json
@@ -1,0 +1,3 @@
+{
+  "message": "Puzzle answer cache cleared"
+}

--- a/docs/openapi/data-examples/examples.yaml
+++ b/docs/openapi/data-examples/examples.yaml
@@ -66,6 +66,11 @@ SetPuzzleResponseWithTeam:
   value:
     $ref: "./SetPuzzleResponseWithTeam.json"
 
+CacheClearResponse:
+  summary: Cache clear confirmation
+  value:
+    $ref: "./CacheClearResponse.json"
+
 # -----------------------------------------------------------------------------
 # User Profile Examples
 # -----------------------------------------------------------------------------

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -194,6 +194,40 @@ paths:
         "403":
           $ref: "#/components/responses/Forbidden"
 
+  /puzzles/cache/clear:
+    post:
+      summary: Clear puzzle answer cache (game admin only)
+      description: |
+        Clear the in-memory cache of puzzle answers.
+
+        This endpoint is useful when puzzle answers have been modified directly in the
+        database (e.g., via AWS console) and the server needs to pick up the changes
+        immediately instead of serving stale cached values.
+
+        **Note:** In a load-balanced environment with multiple server instances, each
+        instance has its own cache. This endpoint only clears the cache on the instance
+        that handles the request. To ensure all instances are updated, either call this
+        endpoint multiple times or restart all instances.
+
+        Only users with app_metadata.game_admin = true can access this endpoint.
+      operationId: clearPuzzleCache
+      tags:
+        - Admin
+      responses:
+        "200":
+          description: Cache cleared successfully
+          content:
+            application/json:
+              schema:
+                $ref: "schemas.yaml#/CacheClearResponse"
+              examples:
+                default:
+                  $ref: "data-examples/examples.yaml#/CacheClearResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+
   /puzzles/{date}:
     get:
       summary: Get a single puzzle by date

--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -500,6 +500,16 @@ SetPuzzleResponse:
       description: Team ID if set
       example: "team-123"
 
+CacheClearResponse:
+  type: object
+  required:
+    - message
+  properties:
+    message:
+      type: string
+      description: Confirmation message
+      example: "Puzzle answer cache cleared"
+
 # -----------------------------------------------------------------------------
 # Common Schemas
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add `POST /puzzles/cache/clear` endpoint to OpenAPI spec
- Add CacheClearResponse schema and example
- Document DynamoDB single-table design in README

## Changes

### OpenAPI Updates
- New endpoint documentation for cache clearing
- Response schema and example for the endpoint

### README DynamoDB Documentation
- Table structure with partition key (pk) and sort key (sk) patterns
- Entity details for Game State and Puzzle Answer
- Access patterns table
- Caching behavior explanation and cache invalidation notes

## Test plan
- [x] Code compiles
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)