### PR TITLE
fix: Use secrets instead of vars for AWS config in GHA workflows

### DIFF
--- a/.github/workflows/deploy-prerequisite.yml
+++ b/.github/workflows/deploy-prerequisite.yml
@@ -9,7 +9,7 @@
 # - Adding new long-lived resources (S3 buckets, etc.)
 # - Updating prerequisite infrastructure independently of the main service
 #
-# Required GitHub Variables (same as deploy.yml):
+# Required GitHub Secrets (same as deploy.yml):
 # - AWS_ACCOUNT_ID
 # - AWS_REGION
 # - AWS_OIDC_ROLE_ARN
@@ -34,7 +34,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  AWS_REGION: ${{ vars.AWS_REGION }}
+  AWS_REGION: ${{ secrets.AWS_REGION }}
 
 jobs:
   deploy-prerequisite:
@@ -50,7 +50,7 @@ jobs:
       - name: Configure AWS credentials via OIDC
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ vars.AWS_OIDC_ROLE_ARN }}
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Setup Node.js
@@ -69,7 +69,7 @@ jobs:
         working-directory: infra
         run: npx cdk diff PrerequisiteInfraStack -c prerequisite=true
         env:
-          CDK_DEFAULT_ACCOUNT: ${{ vars.AWS_ACCOUNT_ID }}
+          CDK_DEFAULT_ACCOUNT: ${{ secrets.AWS_ACCOUNT_ID }}
           CDK_DEFAULT_REGION: ${{ env.AWS_REGION }}
 
       - name: Deploy Prerequisite Infrastructure
@@ -77,7 +77,7 @@ jobs:
         working-directory: infra
         run: npx cdk deploy PrerequisiteInfraStack --require-approval never -c prerequisite=true
         env:
-          CDK_DEFAULT_ACCOUNT: ${{ vars.AWS_ACCOUNT_ID }}
+          CDK_DEFAULT_ACCOUNT: ${{ secrets.AWS_ACCOUNT_ID }}
           CDK_DEFAULT_REGION: ${{ env.AWS_REGION }}
 
       - name: Destroy Prerequisite Infrastructure
@@ -85,7 +85,7 @@ jobs:
         working-directory: infra
         run: npx cdk destroy PrerequisiteInfraStack --force -c prerequisite=true
         env:
-          CDK_DEFAULT_ACCOUNT: ${{ vars.AWS_ACCOUNT_ID }}
+          CDK_DEFAULT_ACCOUNT: ${{ secrets.AWS_ACCOUNT_ID }}
           CDK_DEFAULT_REGION: ${{ env.AWS_REGION }}
 
       - name: Show stack outputs

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,21 +3,15 @@
 # This workflow deploys the scorekeeper service to AWS ECS Fargate using CDK.
 # It triggers after the CI workflow passes on the main branch.
 #
-# Required GitHub Variables (Settings → Secrets and variables → Actions → Variables):
-# -----------------------------------------------------------------------------------
+# Required GitHub Secrets (Settings → Secrets and variables → Actions → Secrets):
+# ---------------------------------------------------------------------------------
 # AWS_ACCOUNT_ID: Your AWS account ID (e.g., 123456789012)
 # AWS_REGION: AWS region to deploy to (e.g., us-west-2)
 # AWS_OIDC_ROLE_ARN: The ARN of the IAM role for GitHub OIDC authentication
 #                    (e.g., arn:aws:iam::123456789012:role/GitHubActions-scorekeeper)
-#
-# Required GitHub Secrets (Settings → Secrets and variables → Actions → Secrets):
-# ---------------------------------------------------------------------------------
 # AUTH0_M2M_SECRET_ARN: The ARN of the Secrets Manager secret containing Auth0 M2M credentials
 #                       (e.g., arn:aws:secretsmanager:us-west-2:123456789012:secret:scorekeeper/auth0-m2m-xxxxx)
 #                       The secret should contain JSON: {"clientId": "...", "clientSecret": "..."}
-#
-# Note: These don't need to be secrets - the role ARN is not sensitive since
-# the OIDC trust policy restricts who can assume it.
 #
 # AWS OIDC Setup:
 # ---------------
@@ -80,7 +74,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  AWS_REGION: ${{ vars.AWS_REGION }}
+  AWS_REGION: ${{ secrets.AWS_REGION }}
   ECR_REPOSITORY: scorekeeper
 
 jobs:
@@ -103,7 +97,7 @@ jobs:
       - name: Configure AWS credentials via OIDC
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ vars.AWS_OIDC_ROLE_ARN }}
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Setup Node.js
@@ -121,7 +115,7 @@ jobs:
         working-directory: infra
         run: npx cdk ${{ env.CDK_ACTION }} ${{ env.CDK_ACTION == 'destroy' && '--force' || '' }} PrerequisiteInfraStack --require-approval never -c prerequisite=true
         env:
-          CDK_DEFAULT_ACCOUNT: ${{ vars.AWS_ACCOUNT_ID }}
+          CDK_DEFAULT_ACCOUNT: ${{ secrets.AWS_ACCOUNT_ID }}
           CDK_DEFAULT_REGION: ${{ env.AWS_REGION }}
 
       - name: Get stack outputs
@@ -154,7 +148,7 @@ jobs:
       #     - name: Configure AWS credentials via OIDC
       #       uses: aws-actions/configure-aws-credentials@v4
       #       with:
-      #         role-to-assume: ${{ vars.AWS_OIDC_ROLE_ARN }}
+      #         role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
       #         aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to Amazon ECR
@@ -204,7 +198,7 @@ jobs:
       # - name: Configure AWS credentials via OIDC
       #   uses: aws-actions/configure-aws-credentials@v4
       #   with:
-      #     role-to-assume: ${{ vars.AWS_OIDC_ROLE_ARN }}
+      #     role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
       #     aws-region: ${{ env.AWS_REGION }}
 
       # - name: Setup Node.js
@@ -222,7 +216,7 @@ jobs:
         working-directory: infra
         run: npx cdk ${{ env.CDK_ACTION }} ${{ env.CDK_ACTION == 'destroy' && ' --force' || '' }} --require-approval never -c env=prod -c auth0M2mSecretArn=${{ secrets.AUTH0_M2M_SECRET_ARN }}
         env:
-          CDK_DEFAULT_ACCOUNT: ${{ vars.AWS_ACCOUNT_ID }}
+          CDK_DEFAULT_ACCOUNT: ${{ secrets.AWS_ACCOUNT_ID }}
           CDK_DEFAULT_REGION: ${{ env.AWS_REGION }}
 
       - name: Force new ECS deployment


### PR DESCRIPTION
## Summary
- Replace all `vars.AWS_ACCOUNT_ID`, `vars.AWS_REGION`, `vars.AWS_OIDC_ROLE_ARN` with `secrets.*` equivalents
- Update documentation comments to reflect that all AWS config now comes from secrets
- GitHub Actions vars have been deleted, so workflows need to use secrets exclusively

## Test plan
- [ ] Verify the deploy workflow runs successfully after merge
- [ ] Verify the deploy-prerequisite workflow can be triggered manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)