### PR TITLE
fix: Make OTel collector conditional on secrets to unblock deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -228,7 +228,6 @@ jobs:
           npx cdk ${{ env.CDK_ACTION }} ${{ env.CDK_ACTION == 'destroy' && ' --force' || '' }} \
             ScorekeeperStack \
             --require-approval never \
-            -c env=prod \
             -c auth0M2mSecretArn=${{ secrets.AUTH0_M2M_SECRET_ARN }} \
             ${{ secrets.OTEL_SECRETS_ARN && format('-c otelSecretsArn={0}', secrets.OTEL_SECRETS_ARN) || '' }}
         env:

--- a/infra/cdk.context.json
+++ b/infra/cdk.context.json
@@ -9,9 +9,5 @@
     "us-west-2d"
   ],
   "domainName": "wordles.dev",
-  "apiSubdomain": "api",
-  "hosted-zone:account=587838441384:domainName=api.wordles.dev:region=us-west-2": {
-    "Id": "/hostedzone/Z07786182A2PDFCIUBB8V",
-    "Name": "api.wordles.dev."
-  }
+  "apiSubdomain": "api"
 }

--- a/infra/lib/infra-stack.ts
+++ b/infra/lib/infra-stack.ts
@@ -228,68 +228,51 @@ export class ScorekeeperStack extends cdk.Stack {
       interval: cdk.Duration.seconds(30),
     });
 
-    // Build OTel collector image from local Dockerfile
-    const collectorImage = new ecrAssets.DockerImageAsset(this, 'CollectorImage', {
-      directory: path.join(__dirname, '../../collector'),
-    });
+    // OTel collector sidecar — only deploy when Grafana secrets are configured.
+    // Without secrets the collector crashes, its ALB target group fails health
+    // checks, and ECS circuit breaker rolls back the entire deployment.
+    // The scorekeeper app's OTel SDK handles connection-refused gracefully (drops spans).
+    if (otelSecrets) {
+      const collectorImage = new ecrAssets.DockerImageAsset(this, 'CollectorImage', {
+        directory: path.join(__dirname, '../../collector'),
+      });
 
-    // Add OTel collector sidecar container to the task definition
-    const collectorContainer = fargateService.taskDefinition.addContainer('otel-collector', {
-      image: ecs.ContainerImage.fromDockerImageAsset(collectorImage),
-      memoryLimitMiB: 128,
-      cpu: 64,
-      essential: false, // Don't kill task if collector crashes
-      logging: ecs.LogDrivers.awsLogs({
-        streamPrefix: 'otel-collector',
-        logRetention: logs.RetentionDays.ONE_WEEK,
-      }),
-      environment: {
-        ENVIRONMENT: environmentName,
-      },
-      // Grafana Cloud credentials from Secrets Manager (if configured)
-      ...(otelSecrets
-        ? {
-            secrets: {
-              GRAFANA_OTLP_ENDPOINT: ecs.Secret.fromSecretsManager(otelSecrets, 'GRAFANA_OTLP_ENDPOINT'),
-              GRAFANA_INSTANCE_ID: ecs.Secret.fromSecretsManager(otelSecrets, 'GRAFANA_INSTANCE_ID'),
-              GRAFANA_API_KEY: ecs.Secret.fromSecretsManager(otelSecrets, 'GRAFANA_API_KEY'),
-            },
-          }
-        : {}),
-    });
+      const collectorContainer = fargateService.taskDefinition.addContainer('otel-collector', {
+        image: ecs.ContainerImage.fromDockerImageAsset(collectorImage),
+        memoryLimitMiB: 128,
+        cpu: 64,
+        essential: false,
+        logging: ecs.LogDrivers.awsLogs({
+          streamPrefix: 'otel-collector',
+          logRetention: logs.RetentionDays.ONE_WEEK,
+        }),
+        environment: {
+          ENVIRONMENT: environmentName,
+        },
+        secrets: {
+          GRAFANA_OTLP_ENDPOINT: ecs.Secret.fromSecretsManager(otelSecrets, 'GRAFANA_OTLP_ENDPOINT'),
+          GRAFANA_INSTANCE_ID: ecs.Secret.fromSecretsManager(otelSecrets, 'GRAFANA_INSTANCE_ID'),
+          GRAFANA_API_KEY: ecs.Secret.fromSecretsManager(otelSecrets, 'GRAFANA_API_KEY'),
+        },
+      });
 
-    // Add port mappings for the collector
-    collectorContainer.addPortMappings(
-      { containerPort: 4317, protocol: ecs.Protocol.TCP }, // OTLP gRPC (backend)
-      { containerPort: 4318, protocol: ecs.Protocol.TCP }, // OTLP HTTP (frontend)
-      { containerPort: 13133, protocol: ecs.Protocol.TCP } // health check
-    );
+      collectorContainer.addPortMappings(
+        { containerPort: 4317, protocol: ecs.Protocol.TCP },
+        { containerPort: 4318, protocol: ecs.Protocol.TCP },
+        { containerPort: 13133, protocol: ecs.Protocol.TCP },
+      );
 
-    // Add target group for OTLP HTTP (frontend traces) - /v1/traces path
-    const otelTargetGroup = new elbv2.ApplicationTargetGroup(this, 'OtelHttpTarget', {
-      vpc,
-      port: 4318,
-      protocol: elbv2.ApplicationProtocol.HTTP,
-      targetGroupName: `otel-collector-${environmentName}`,
-      targetType: elbv2.TargetType.IP,
-      healthCheck: {
-        path: '/',
-        port: '13133',
-        healthyHttpCodes: '200',
-      },
-    });
-
-    // Register the service with the OTel target group
-    fargateService.service.registerLoadBalancerTargets({
-      containerName: 'otel-collector',
-      containerPort: 4318,
-      newTargetGroupId: 'otel-collector',
-      listener: ecs.ListenerConfig.applicationListener(fargateService.listener, {
-        protocol: elbv2.ApplicationProtocol.HTTPS,
-        conditions: [elbv2.ListenerCondition.pathPatterns(['/v1/traces'])],
-        priority: 10,
-      }),
-    });
+      fargateService.service.registerLoadBalancerTargets({
+        containerName: 'otel-collector',
+        containerPort: 4318,
+        newTargetGroupId: 'otel-collector',
+        listener: ecs.ListenerConfig.applicationListener(fargateService.listener, {
+          protocol: elbv2.ApplicationProtocol.HTTPS,
+          conditions: [elbv2.ListenerCondition.pathPatterns(['/v1/traces'])],
+          priority: 10,
+        }),
+      });
+    }
 
     // Auto-scaling configuration for production
     if (isProd) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -253,9 +253,7 @@ async fn main() -> std::io::Result<()> {
             if let Some(ref s3) = s3_avatar_service {
                 app = app.app_data(s3.clone());
             }
-            app = app
-                .service(get_profile)
-                .service(update_profile);
+            app = app.service(get_profile).service(update_profile);
             if s3_avatar_service.is_some() {
                 app = app.service(upload_avatar);
             }

--- a/src/services/s3_avatar.rs
+++ b/src/services/s3_avatar.rs
@@ -1,7 +1,7 @@
 //! S3 Avatar upload service.
 
-use aws_sdk_s3::Client as S3Client;
 use aws_sdk_s3::presigning::PresigningConfig;
+use aws_sdk_s3::Client as S3Client;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tracing::{debug, error};
 
@@ -111,10 +111,11 @@ impl S3AvatarService {
 
     /// Generates a pre-signed GET URL for the given S3 key.
     pub async fn get_presigned_url(&self, key: &str) -> Result<String, AppError> {
-        let presigning_config = PresigningConfig::expires_in(PRESIGNED_URL_EXPIRY).map_err(|e| {
-            error!("Failed to create presigning config: {}", e);
-            AppError::internal("Failed to generate avatar URL")
-        })?;
+        let presigning_config =
+            PresigningConfig::expires_in(PRESIGNED_URL_EXPIRY).map_err(|e| {
+                error!("Failed to create presigning config: {}", e);
+                AppError::internal("Failed to generate avatar URL")
+            })?;
 
         let presigned_request = self
             .client


### PR DESCRIPTION
## Summary

- **Wrapped OTel collector sidecar in `if (otelSecrets)`** — image build, container, port mappings, and ALB target group only created when Grafana secrets are configured
- **Deleted orphaned `OtelHttpTarget` target group** — was created but never properly associated with the service
- **Removed unused `-c env=prod`** from CDK deploy command in CI workflow
- **Removed stale `hosted-zone:...` cache** from `cdk.context.json` pointing to old stack's hosted zone

## Root Cause

PR #90 added an OTel collector sidecar that registers a second ALB target group. During deployment, ECS circuit breaker requires ALL target groups to be healthy. Without the `OTEL_SECRETS_ARN` GitHub secret configured, the collector crashes on startup → its target group fails health checks → circuit breaker rolls back the entire deployment.

## How It Works Now

| `OTEL_SECRETS_ARN` set? | Collector deployed? | ALB target groups | Deploys depend on |
|---|---|---|---|
| Yes | Yes (with Grafana creds) | scorekeeper + otel-collector | Both healthy |
| No | No | scorekeeper only | Scorekeeper healthy |

The scorekeeper app always sets `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317`. Without the collector, the OTel SDK handles connection-refused gracefully (drops spans, no crash).

## Test plan

- [x] `cd infra && npm test` — all 8 CDK tests pass
- [x] `cargo test` — all 249 Rust tests pass
- [ ] Deploy without `OTEL_SECRETS_ARN` → no collector in task def, service stabilizes
- [ ] `curl https://api.wordles.dev/health` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)