### PR TITLE
fix: Add health check to OTel collector target group

### DIFF
--- a/infra/lib/infra-stack.ts
+++ b/infra/lib/infra-stack.ts
@@ -270,6 +270,11 @@ export class ScorekeeperStack extends cdk.Stack {
           protocol: elbv2.ApplicationProtocol.HTTPS,
           conditions: [elbv2.ListenerCondition.pathPatterns(['/v1/traces'])],
           priority: 10,
+          healthCheck: {
+            path: '/',
+            port: '13133',
+            healthyHttpCodes: '200',
+          },
         }),
       });
     }


### PR DESCRIPTION
## Summary
- The OTel collector's ALB target group was using the default health check (port 4318, path `/`), but the OTLP HTTP receiver returns 404 for `GET /`
- This caused health checks to perpetually fail, triggering the ECS deployment circuit breaker
- Points the health check at port 13133 where the collector's `health_check` extension returns 200

## Root cause
`registerLoadBalancerTargets` creates a target group that defaults to health-checking on the traffic port (4318). The OTLP receiver only accepts `POST /v1/traces` — any `GET` returns 404/405. The collector exposes a dedicated health endpoint on port 13133 via the `health_check` extension.

## Test plan
- [x] CDK tests pass (8/8)
- [x] Rust tests pass (125/125)
- [ ] Deploy succeeds — ECS service stabilizes without circuit breaker rollback
- [ ] `curl https://api.wordles.dev/health` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)