### PR TITLE
fix: Use HTTP protocol and open health check port for OTel collector target group

### DIFF
--- a/infra/lib/infra-stack.ts
+++ b/infra/lib/infra-stack.ts
@@ -267,7 +267,7 @@ export class ScorekeeperStack extends cdk.Stack {
         containerPort: 4318,
         newTargetGroupId: 'otel-collector',
         listener: ecs.ListenerConfig.applicationListener(fargateService.listener, {
-          protocol: elbv2.ApplicationProtocol.HTTPS,
+          protocol: elbv2.ApplicationProtocol.HTTP,
           conditions: [elbv2.ListenerCondition.pathPatterns(['/v1/traces'])],
           priority: 10,
           healthCheck: {
@@ -277,6 +277,14 @@ export class ScorekeeperStack extends cdk.Stack {
           },
         }),
       });
+
+      // Allow ALB to reach the collector health check port (13133).
+      // CDK only auto-creates SG rules for the traffic port (4318).
+      fargateService.service.connections.allowFrom(
+        fargateService.loadBalancer,
+        ec2.Port.tcp(13133),
+        'ALB to OTel collector health check',
+      );
     }
 
     // Auto-scaling configuration for production


### PR DESCRIPTION
## Summary
- Changed the OTel collector ALB target group protocol from HTTPS to HTTP — the collector speaks plain HTTP on port 4318, so the ALB couldn't complete a TLS handshake and marked all targets unhealthy
- Added security group rule allowing the ALB to reach the collector's health check port (13133) — CDK only auto-creates SG rules for the traffic port (4318), so health checks were blocked

Both issues caused the ALB target group to report unhealthy targets → ECS deployment circuit breaker → rollback.

## Root cause
PR #96 configured the health check correctly (port 13133, path `/`) but:
1. `protocol: elbv2.ApplicationProtocol.HTTPS` set the target group protocol to HTTPS, not the listener protocol — the ALB tried to TLS-handshake with a plain HTTP endpoint
2. `registerLoadBalancerTargets` only creates SG rules for `containerPort` (4318), not the health check port (13133)

## Test plan
- [x] `cdk synth` succeeds
- [x] Synthesized template shows `Protocol: HTTP` on the collector target group
- [x] Synthesized template includes SG ingress/egress rules for port 13133
- [x] All Rust tests pass (123 lib + 125 bin + 1 integration)
- [x] All CDK tests pass (8/8)
- [ ] Deploy succeeds and ECS service stabilizes without circuit breaker

🤖 Generated with [Claude Code](https://claude.com/claude-code)