### PR TITLE
Add reporter info to GitHub issues from Auth0 profile

### DIFF
--- a/src/routes/issues.rs
+++ b/src/routes/issues.rs
@@ -6,18 +6,20 @@ use tracing::instrument;
 
 use crate::middleware::auth::Claims;
 use crate::models::error::AppError;
+use crate::services::auth0::Auth0ManagementService;
 use crate::services::github_issues::IssueRequest;
 use crate::services::{GitHubIssueService, RateLimiter};
 
 /// POST /issues - Create a GitHub issue on behalf of an authenticated user.
 #[post("/issues")]
-#[instrument(name = "create_issue", skip(body, service, rate_limiter), fields(user_id = %claims.sub))]
+#[instrument(name = "create_issue", skip(body, service, rate_limiter, auth0_service), fields(user_id = %claims.sub))]
 pub async fn create_issue(
     req: HttpRequest,
     claims: Claims,
     body: web::Json<IssueRequest>,
     service: web::Data<GitHubIssueService>,
     rate_limiter: web::Data<RateLimiter>,
+    auth0_service: web::Data<Auth0ManagementService>,
 ) -> Result<HttpResponse, AppError> {
     // Rate limiting: 5 issues per IP per hour
     let source_ip = req
@@ -53,8 +55,23 @@ pub async fn create_issue(
         })));
     }
 
+    // Resolve reporter info from JWT claims + Auth0 user profile
+    let user_id = claims.sub.clone();
+    let display_name = match auth0_service.get_user(&user_id).await {
+        Ok(user) => user
+            .user_metadata
+            .map(|m| m.display_name)
+            .filter(|n| !n.is_empty()),
+        Err(e) => {
+            tracing::warn!("Failed to fetch reporter profile: {}", e);
+            None
+        }
+    };
+
     // Delegate to service (Turnstile verification + GitHub API call)
-    let response = service.create_issue(&body).await?;
+    let response = service
+        .create_issue(&body, display_name.as_deref(), Some(&user_id))
+        .await?;
 
     tracing::info!("Created issue #{} from IP {}", response.issue_number, source_ip);
 

--- a/src/services/github_issues.rs
+++ b/src/services/github_issues.rs
@@ -128,12 +128,24 @@ fn get_template(issue_type: &str) -> IssueTemplate {
 fn build_issue_body(
     issue_type: &str,
     description: &str,
+    reporter_display_name: Option<&str>,
+    reporter_user_id: Option<&str>,
     user_agent: Option<&str>,
     page_url: Option<&str>,
 ) -> String {
     let template = get_template(issue_type);
     let body = template.body.replace("{description}", description);
     let mut result = body.trim_end().to_string();
+
+    if reporter_display_name.is_some() || reporter_user_id.is_some() {
+        result.push_str("\n\n## Reporter\n");
+        if let Some(name) = reporter_display_name {
+            result.push_str(&format!("- Name: {}\n", name));
+        }
+        if let Some(id) = reporter_user_id {
+            result.push_str(&format!("- User ID: `{}`\n", id));
+        }
+    }
 
     if user_agent.is_some() || page_url.is_some() {
         result.push_str("\n\n## Environment\n");
@@ -337,7 +349,13 @@ impl GitHubIssueService {
     }
 
     /// Create a GitHub issue. Handles Turnstile verification and GitHub API call.
-    pub async fn create_issue(&self, request: &IssueRequest) -> Result<IssueResponse, AppError> {
+    /// Reporter info is resolved from the authenticated user's JWT and Auth0 profile.
+    pub async fn create_issue(
+        &self,
+        request: &IssueRequest,
+        reporter_display_name: Option<&str>,
+        reporter_user_id: Option<&str>,
+    ) -> Result<IssueResponse, AppError> {
         // Verify Turnstile token
         self.verify_turnstile(&request.turnstile_token).await?;
 
@@ -351,6 +369,8 @@ impl GitHubIssueService {
             body: build_issue_body(
                 &request.issue_type,
                 &request.description,
+                reporter_display_name,
+                reporter_user_id,
                 request.user_agent.as_deref(),
                 request.page_url.as_deref(),
             ),
@@ -447,7 +467,7 @@ mod tests {
 
     #[test]
     fn build_issue_body_replaces_description() {
-        let body = build_issue_body("bug", "Test description here", None, None);
+        let body = build_issue_body("bug", "Test description here", None, None, None, None);
         assert!(
             body.contains("Test description here"),
             "description not inserted into body"
@@ -457,9 +477,9 @@ mod tests {
 
     #[test]
     fn build_issue_body_includes_footer() {
-        let body = build_issue_body("bug", "Test", None, None);
+        let body = build_issue_body("bug", "Test", None, None, None, None);
         assert!(
-            body.contains("Submitted anonymously"),
+            body.contains("Submitted via"),
             "footer not appended"
         );
     }
@@ -469,6 +489,8 @@ mod tests {
         let body = build_issue_body(
             "bug",
             "Test",
+            None,
+            None,
             Some("Mozilla/5.0 (Macintosh)"),
             Some("https://wordles.dev/gamemaker"),
         );
@@ -484,8 +506,35 @@ mod tests {
     }
 
     #[test]
+    fn build_issue_body_includes_reporter_section() {
+        let body = build_issue_body(
+            "bug",
+            "Test",
+            Some("Hannah"),
+            Some("auth0|abc123"),
+            None,
+            None,
+        );
+        assert!(body.contains("## Reporter"), "missing reporter section");
+        assert!(body.contains("- Name: Hannah"), "missing reporter name");
+        assert!(
+            body.contains("- User ID: `auth0|abc123`"),
+            "missing reporter user ID"
+        );
+    }
+
+    #[test]
+    fn build_issue_body_omits_reporter_when_absent() {
+        let body = build_issue_body("bug", "Test", None, None, None, None);
+        assert!(
+            !body.contains("## Reporter"),
+            "reporter section should not appear"
+        );
+    }
+
+    #[test]
     fn build_issue_body_omits_environment_when_absent() {
-        let body = build_issue_body("bug", "Test", None, None);
+        let body = build_issue_body("bug", "Test", None, None, None, None);
         assert!(
             !body.contains("## Environment"),
             "environment section should not appear"

--- a/templates/footer.md
+++ b/templates/footer.md
@@ -1,4 +1,4 @@
 
 ---
 
-_Submitted anonymously via [Wordles with Friends GitHub Bot 🤖](https://wordles.dev)_
+_Submitted via [Wordles with Friends GitHub Bot 🤖](https://wordles.dev)_


### PR DESCRIPTION
## Summary
- Resolve reporter display name and user ID server-side by calling the Auth0 Management API from the issues route handler
- Render a `## Reporter` section in the GitHub issue body with name and user ID
- Gracefully degrade if the Auth0 profile lookup fails (log warning, continue without reporter info)
- Update footer template from "Submitted anonymously" to "Submitted via"

## Test plan
- [ ] Submit an issue as an authenticated user and verify the GitHub issue contains a Reporter section with correct name and user ID
- [ ] Verify existing issue types (bug, feature, question) still render correctly
- [ ] Run `cargo test` — 17 github_issues tests pass including 2 new reporter tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)