### PR TITLE
Switch Auth0 domain to production tenant

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -56,7 +56,8 @@ services:
     environment:
       - HOST=0.0.0.0
       - PORT=8080
-      - AUTH0_DOMAIN=dev-g32naui5mvpwnsg7.us.auth0.com
+      # - AUTH0_DOMAIN=dev-g32naui5mvpwnsg7.us.auth0.com
+      - AUTH0_DOMAIN=scovill.us.auth0.com
       - AUTH0_AUDIENCE=com.hannahscovill.scorekeeper
       - AUTH0_M2M_CLIENT_ID=${AUTH0_M2M_CLIENT_ID}
       - AUTH0_M2M_CLIENT_SECRET=${AUTH0_M2M_CLIENT_SECRET}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,7 +76,8 @@ services:
     environment:
       - HOST=0.0.0.0
       - PORT=8080
-      - AUTH0_DOMAIN=dev-g32naui5mvpwnsg7.us.auth0.com
+      # - AUTH0_DOMAIN=dev-g32naui5mvpwnsg7.us.auth0.com
+      - AUTH0_DOMAIN=scovill.us.auth0.com
       - AUTH0_AUDIENCE=com.hannahscovill.scorekeeper
       - AUTH0_M2M_CLIENT_ID=${AUTH0_M2M_CLIENT_ID}
       - AUTH0_M2M_CLIENT_SECRET=${AUTH0_M2M_CLIENT_SECRET}

--- a/src/config.rs
+++ b/src/config.rs
@@ -102,7 +102,8 @@ impl Default for Config {
             host: "0.0.0.0".to_string(),
             port: 8080,
             database_url: None,
-            auth0_domain: "dev-g32naui5mvpwnsg7.us.auth0.com".to_string(),
+            // Dev tenant: "dev-g32naui5mvpwnsg7.us.auth0.com"
+            auth0_domain: "scovill.us.auth0.com".to_string(),
             auth0_audience: "com.hannahscovill.scorekeeper".to_string(),
             auth0_m2m_client_id: None,
             auth0_m2m_client_secret: None,
@@ -154,7 +155,8 @@ impl Config {
                 .unwrap_or(8080),
             database_url: std::env::var("DATABASE_URL").ok(),
             auth0_domain: std::env::var("AUTH0_DOMAIN")
-                .unwrap_or_else(|_| "dev-g32naui5mvpwnsg7.us.auth0.com".to_string()),
+                // Dev tenant: "dev-g32naui5mvpwnsg7.us.auth0.com"
+                .unwrap_or_else(|_| "scovill.us.auth0.com".to_string()),
             auth0_audience: std::env::var("AUTH0_AUDIENCE")
                 .unwrap_or_else(|_| "com.hannahscovill.scorekeeper".to_string()),
             auth0_m2m_client_id: std::env::var("AUTH0_M2M_CLIENT_ID").ok(),
@@ -341,7 +343,7 @@ mod tests {
         assert_eq!(config.host, "0.0.0.0");
         assert_eq!(config.port, 8080);
         assert!(config.database_url.is_none());
-        assert_eq!(config.auth0_domain, "dev-g32naui5mvpwnsg7.us.auth0.com");
+        assert_eq!(config.auth0_domain, "scovill.us.auth0.com");
         assert_eq!(config.auth0_audience, "com.hannahscovill.scorekeeper");
         assert!(config.auth0_m2m_client_id.is_none());
         assert!(config.auth0_m2m_client_secret.is_none());


### PR DESCRIPTION
## Summary
- Switch Auth0 domain default from dev (`dev-g32naui5mvpwnsg7.us.auth0.com`) to prod (`scovill.us.auth0.com`) across config.rs, docker-compose.yml, and docker-compose.dev.yml
- Dev tenant domain preserved as comments for easy local switching
- Fixes 401 "Unknown key ID" errors when the frontend sends tokens signed by the prod Auth0 tenant

## Context
The frontend is being switched to the production Auth0 tenant (`scovill.us.auth0.com`). The backend needs to validate JWTs against the prod tenant's JWKS keys and issuer URL, otherwise requests fail with `UNAUTHORIZED: Unknown key ID`.

This change affects:
- **JWKS validation** — fetches signing keys from `scovill.us.auth0.com/.well-known/jwks.json`
- **Issuer check** — validates `iss` claim against `https://scovill.us.auth0.com/`
- **M2M token endpoint** — requests management API tokens from the prod tenant

## Note
The Auth0 M2M client credentials in `.env` / Secrets Manager will also need to be updated to the prod tenant's M2M application credentials separately.

## Test plan
- [x] `cargo test` — all 148 unit tests pass
- [x] CDK tests — all 8 pass
- [ ] After merge + deploy, verify authenticated API calls work with prod Auth0 tokens
- [ ] Verify M2M credentials are updated in Secrets Manager for the prod tenant

🤖 Generated with [Claude Code](https://claude.com/claude-code)