### PR TITLE
Fix GitHub App secret key names to match Secrets Manager

### DIFF
--- a/infra/cdk.context.json
+++ b/infra/cdk.context.json
@@ -9,5 +9,9 @@
     "us-west-2d"
   ],
   "domainName": "wordles.dev",
-  "apiSubdomain": "api"
+  "apiSubdomain": "api",
+  "hosted-zone:account=587838441384:domainName=api.wordles.dev:region=us-west-2": {
+    "Id": "/hostedzone/Z07786182A2PDFCIUBB8V",
+    "Name": "api.wordles.dev."
+  }
 }

--- a/infra/lib/infra-stack.ts
+++ b/infra/lib/infra-stack.ts
@@ -54,7 +54,7 @@ export interface ScorekeeperStackProps extends cdk.StackProps {
 
   /**
    * ARN of the Secrets Manager secret containing GitHub App credentials for the issue proxy.
-   * The secret should be a JSON object with 'appId', 'installationId', and 'privateKey' fields.
+   * The secret should be a JSON object with 'app-id', 'installation-id', and 'private-key' fields.
    * If not provided, the /issues endpoint will not be available.
    */
   readonly githubAppSecretArn?: string;
@@ -234,9 +234,9 @@ export class ScorekeeperStack extends cdk.Stack {
             }),
             // GitHub App credentials for issue proxy
             ...(githubAppSecret && {
-              GITHUB_APP_ID: ecs.Secret.fromSecretsManager(githubAppSecret, 'appId'),
-              GITHUB_INSTALLATION_ID: ecs.Secret.fromSecretsManager(githubAppSecret, 'installationId'),
-              GITHUB_PRIVATE_KEY: ecs.Secret.fromSecretsManager(githubAppSecret, 'privateKey'),
+              GITHUB_APP_ID: ecs.Secret.fromSecretsManager(githubAppSecret, 'app-id'),
+              GITHUB_INSTALLATION_ID: ecs.Secret.fromSecretsManager(githubAppSecret, 'installation-id'),
+              GITHUB_PRIVATE_KEY: ecs.Secret.fromSecretsManager(githubAppSecret, 'private-key'),
             }),
             // Turnstile CAPTCHA secret for issue proxy
             ...(turnstileSecret && {


### PR DESCRIPTION
## Summary
- The `wordles/scorekeeper/github-app` secret uses kebab-case keys (`app-id`, `installation-id`, `private-key`) but the CDK stack was referencing camelCase (`appId`, `installationId`, `privateKey`)
- ECS tasks failed at secret resolution during container startup, triggering the deployment circuit breaker and rolling back the deploy
- Updated `infra/lib/infra-stack.ts` to use the correct kebab-case key names

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] CDK tests pass (8/8)
- [x] Rust tests pass (146/146)
- [x] Deploy succeeds and ECS tasks start with correct secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)