### PR TITLE
Add client/server environment metadata to issue reports

### DIFF
--- a/docs/bruno/Issues/Create Issue.bru
+++ b/docs/bruno/Issues/Create Issue.bru
@@ -27,7 +27,10 @@ body:json {
     "turnstileToken": "0.test-token",
     "website": "",
     "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)",
-    "pageUrl": "https://wordles.dev/play"
+    "pageUrl": "https://wordles.dev/play",
+    "posthogSessionId": "019470a2-b3c4-7d8e-9f0a-1b2c3d4e5f6a",
+    "clientEnvironmentName": "local",
+    "clientCommitHash": "a1b2c3d"
   }
 }
 
@@ -35,7 +38,10 @@ docs {
   Submit an issue report. Creates a GitHub issue on behalf of the authenticated user.
 
   The reporter's user ID (from JWT) and display name (from Auth0 profile) are
-  included in the issue body. The server's deploy commit hash is also included.
+  included in the issue body. PostHog session ID is included for session replay
+  correlation. The issue body includes separate Client and Server environment
+  sections — client metadata is sent by the frontend, server metadata is
+  appended by the backend from its own deployment context.
 
   ## Authentication
   Requires a valid Bearer token (inherited from collection).
@@ -48,6 +54,9 @@ docs {
   - `website` (string, optional): Honeypot field — should always be empty
   - `userAgent` (string, optional): Browser user-agent string
   - `pageUrl` (string, optional): URL of the page the user was on
+  - `posthogSessionId` (string, optional): PostHog session ID for replay correlation
+  - `clientEnvironmentName` (string, optional): Client deployment environment name
+  - `clientCommitHash` (string, optional): Client git commit hash
 
   ## Responses
   - `201`: Issue created successfully

--- a/docs/openapi/data-examples/IssueRequestBug.json
+++ b/docs/openapi/data-examples/IssueRequestBug.json
@@ -3,5 +3,10 @@
   "title": "Game doesn't load on mobile Safari",
   "description": "When I open the game on my iPhone using Safari, the page shows a blank white screen.",
   "turnstileToken": "0.abc123...",
-  "website": ""
+  "website": "",
+  "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)",
+  "pageUrl": "https://wordles.dev/play",
+  "posthogSessionId": "019470a2-b3c4-7d8e-9f0a-1b2c3d4e5f6a",
+  "clientEnvironmentName": "production",
+  "clientCommitHash": "a1b2c3d"
 }

--- a/docs/openapi/data-examples/IssueRequestFeature.json
+++ b/docs/openapi/data-examples/IssueRequestFeature.json
@@ -3,5 +3,10 @@
   "title": "Add dark mode support",
   "description": "It would be great to have a dark mode option for playing at night.",
   "turnstileToken": "0.abc123...",
-  "website": ""
+  "website": "",
+  "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36",
+  "pageUrl": "https://wordles.dev/profile",
+  "posthogSessionId": "019470a2-b3c4-7d8e-9f0a-1b2c3d4e5f6a",
+  "clientEnvironmentName": "production",
+  "clientCommitHash": "a1b2c3d"
 }

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -283,7 +283,12 @@ paths:
 
         The reporter's user ID is extracted from the JWT and included in the
         issue body. Display name is resolved from the Auth0 user profile when
-        available. The server's deploy commit hash is also included.
+        available. PostHog session ID is included for session replay correlation.
+
+        The issue body includes separate Client and Server environment sections.
+        Client metadata (browser, URL, environment name, commit hash) is sent
+        by the frontend. Server metadata (environment name, commit hash) is
+        appended by the backend from its own deployment context.
 
         Includes Turnstile CAPTCHA verification, honeypot spam detection,
         and per-IP rate limiting (5 issues per hour).

--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -562,10 +562,19 @@ IssueRequest:
       default: ""
     userAgent:
       type: string
-      description: Browser user-agent string (included in the issue's Environment section)
+      description: Browser user-agent string (included in the issue's Client environment section)
     pageUrl:
       type: string
       description: URL of the page the user was on when reporting the issue
+    posthogSessionId:
+      type: string
+      description: PostHog session ID for correlating issue reports with session replays
+    clientEnvironmentName:
+      type: string
+      description: Client deployment environment name (e.g. "local", "production")
+    clientCommitHash:
+      type: string
+      description: Client git commit hash at build time
 
 IssueReportResponse:
   type: object

--- a/src/main.rs
+++ b/src/main.rs
@@ -248,6 +248,7 @@ async fn main() -> std::io::Result<()> {
             config.turnstile_secret_key().map(|s| s.to_string()),
             config.turnstile_verify_url().to_string(),
             std::env::var("COMMIT_HASH").ok(),
+            Some(environment.as_str().to_string()),
         )))
     } else {
         info!("GitHub Issue service disabled (no GitHub credentials configured)");

--- a/src/services/github_issues.rs
+++ b/src/services/github_issues.rs
@@ -131,65 +131,68 @@ fn get_template(issue_type: &str) -> IssueTemplate {
     parse_template(raw)
 }
 
-fn build_issue_body(
-    issue_type: &str,
-    description: &str,
-    reporter_display_name: Option<&str>,
-    reporter_user_id: &str,
-    posthog_session_id: Option<&str>,
-    user_agent: Option<&str>,
-    page_url: Option<&str>,
-    client_environment_name: Option<&str>,
-    client_commit_hash: Option<&str>,
-    server_environment_name: Option<&str>,
-    server_commit_hash: Option<&str>,
-) -> String {
-    let template = get_template(issue_type);
-    let body = template.body.replace("{description}", description);
+struct IssueBodyParams<'a> {
+    issue_type: &'a str,
+    description: &'a str,
+    reporter_display_name: Option<&'a str>,
+    reporter_user_id: &'a str,
+    posthog_session_id: Option<&'a str>,
+    user_agent: Option<&'a str>,
+    page_url: Option<&'a str>,
+    client_environment_name: Option<&'a str>,
+    client_commit_hash: Option<&'a str>,
+    server_environment_name: Option<&'a str>,
+    server_commit_hash: Option<&'a str>,
+}
+
+fn build_issue_body(params: &IssueBodyParams) -> String {
+    let template = get_template(params.issue_type);
+    let body = template.body.replace("{description}", params.description);
     let mut result = body.trim_end().to_string();
 
     // Reporter section
     result.push_str("\n\n## Reporter\n");
-    if let Some(name) = reporter_display_name {
+    if let Some(name) = params.reporter_display_name {
         result.push_str(&format!("- Display Name: {}\n", name));
     }
-    result.push_str(&format!("- User ID: `{}`\n", reporter_user_id));
-    if let Some(session_id) = posthog_session_id {
+    result.push_str(&format!("- User ID: `{}`\n", params.reporter_user_id));
+    if let Some(session_id) = params.posthog_session_id {
         result.push_str(&format!("- Posthog Session ID: `{}`\n", session_id));
     }
 
     // Environment section
-    let has_client = user_agent.is_some()
-        || page_url.is_some()
-        || client_environment_name.is_some()
-        || client_commit_hash.is_some();
-    let has_server = server_environment_name.is_some() || server_commit_hash.is_some();
+    let has_client = params.user_agent.is_some()
+        || params.page_url.is_some()
+        || params.client_environment_name.is_some()
+        || params.client_commit_hash.is_some();
+    let has_server =
+        params.server_environment_name.is_some() || params.server_commit_hash.is_some();
 
     if has_client || has_server {
         result.push_str("\n## Environment\n");
 
         if has_client {
             result.push_str("\n### Client\n");
-            if let Some(ua) = user_agent {
+            if let Some(ua) = params.user_agent {
                 result.push_str(&format!("- Browser: {}\n", ua));
             }
-            if let Some(url) = page_url {
+            if let Some(url) = params.page_url {
                 result.push_str(&format!("- URL: {}\n", url));
             }
-            if let Some(env) = client_environment_name {
+            if let Some(env) = params.client_environment_name {
                 result.push_str(&format!("- Environment Name: `{}`\n", env));
             }
-            if let Some(hash) = client_commit_hash {
+            if let Some(hash) = params.client_commit_hash {
                 result.push_str(&format!("- Commit Hash: `{}`\n", hash));
             }
         }
 
         if has_server {
             result.push_str("\n### Server\n");
-            if let Some(env) = server_environment_name {
+            if let Some(env) = params.server_environment_name {
                 result.push_str(&format!("- Environment Name: `{}`\n", env));
             }
-            if let Some(hash) = server_commit_hash {
+            if let Some(hash) = params.server_commit_hash {
                 result.push_str(&format!("- Commit Hash: `{}`\n", hash));
             }
         }
@@ -419,19 +422,19 @@ impl GitHubIssueService {
 
         let create_issue = GitHubCreateIssue {
             title: full_title,
-            body: build_issue_body(
-                &request.issue_type,
-                &request.description,
+            body: build_issue_body(&IssueBodyParams {
+                issue_type: &request.issue_type,
+                description: &request.description,
                 reporter_display_name,
                 reporter_user_id,
-                request.posthog_session_id.as_deref(),
-                request.user_agent.as_deref(),
-                request.page_url.as_deref(),
-                request.client_environment_name.as_deref(),
-                request.client_commit_hash.as_deref(),
-                self.server_environment_name.as_deref(),
-                self.server_commit_hash.as_deref(),
-            ),
+                posthog_session_id: request.posthog_session_id.as_deref(),
+                user_agent: request.user_agent.as_deref(),
+                page_url: request.page_url.as_deref(),
+                client_environment_name: request.client_environment_name.as_deref(),
+                client_commit_hash: request.client_commit_hash.as_deref(),
+                server_environment_name: self.server_environment_name.as_deref(),
+                server_commit_hash: self.server_commit_hash.as_deref(),
+            }),
             labels: vec![issue_label(&request.issue_type)],
         };
 
@@ -521,19 +524,19 @@ mod tests {
 
     #[test]
     fn build_issue_body_replaces_description() {
-        let body = build_issue_body(
-            "bug",
-            "Test description here",
-            None,
-            "auth0|test",
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-        );
+        let body = build_issue_body(&IssueBodyParams {
+            issue_type: "bug",
+            description: "Test description here",
+            reporter_display_name: None,
+            reporter_user_id: "auth0|test",
+            posthog_session_id: None,
+            user_agent: None,
+            page_url: None,
+            client_environment_name: None,
+            client_commit_hash: None,
+            server_environment_name: None,
+            server_commit_hash: None,
+        });
         assert!(
             body.contains("Test description here"),
             "description not inserted into body"
@@ -543,37 +546,37 @@ mod tests {
 
     #[test]
     fn build_issue_body_includes_footer() {
-        let body = build_issue_body(
-            "bug",
-            "Test",
-            None,
-            "auth0|test",
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-        );
+        let body = build_issue_body(&IssueBodyParams {
+            issue_type: "bug",
+            description: "Test",
+            reporter_display_name: None,
+            reporter_user_id: "auth0|test",
+            posthog_session_id: None,
+            user_agent: None,
+            page_url: None,
+            client_environment_name: None,
+            client_commit_hash: None,
+            server_environment_name: None,
+            server_commit_hash: None,
+        });
         assert!(body.contains("Submitted via"), "footer not appended");
     }
 
     #[test]
     fn build_issue_body_includes_client_environment_section() {
-        let body = build_issue_body(
-            "bug",
-            "Test",
-            None,
-            "auth0|test",
-            None,
-            Some("Mozilla/5.0 (Macintosh)"),
-            Some("https://wordles.dev/gamemaker"),
-            Some("production"),
-            Some("abc1234"),
-            None,
-            None,
-        );
+        let body = build_issue_body(&IssueBodyParams {
+            issue_type: "bug",
+            description: "Test",
+            reporter_display_name: None,
+            reporter_user_id: "auth0|test",
+            posthog_session_id: None,
+            user_agent: Some("Mozilla/5.0 (Macintosh)"),
+            page_url: Some("https://wordles.dev/gamemaker"),
+            client_environment_name: Some("production"),
+            client_commit_hash: Some("abc1234"),
+            server_environment_name: None,
+            server_commit_hash: None,
+        });
         assert!(
             body.contains("## Environment"),
             "missing environment section"
@@ -599,19 +602,19 @@ mod tests {
 
     #[test]
     fn build_issue_body_includes_server_environment_section() {
-        let body = build_issue_body(
-            "bug",
-            "Test",
-            None,
-            "auth0|test",
-            None,
-            None,
-            None,
-            None,
-            None,
-            Some("production"),
-            Some("def5678"),
-        );
+        let body = build_issue_body(&IssueBodyParams {
+            issue_type: "bug",
+            description: "Test",
+            reporter_display_name: None,
+            reporter_user_id: "auth0|test",
+            posthog_session_id: None,
+            user_agent: None,
+            page_url: None,
+            client_environment_name: None,
+            client_commit_hash: None,
+            server_environment_name: Some("production"),
+            server_commit_hash: Some("def5678"),
+        });
         assert!(
             body.contains("## Environment"),
             "missing environment section"
@@ -629,19 +632,19 @@ mod tests {
 
     #[test]
     fn build_issue_body_includes_reporter_section() {
-        let body = build_issue_body(
-            "bug",
-            "Test",
-            Some("Hannah"),
-            "auth0|abc123",
-            Some("posthog-session-123"),
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-        );
+        let body = build_issue_body(&IssueBodyParams {
+            issue_type: "bug",
+            description: "Test",
+            reporter_display_name: Some("Hannah"),
+            reporter_user_id: "auth0|abc123",
+            posthog_session_id: Some("posthog-session-123"),
+            user_agent: None,
+            page_url: None,
+            client_environment_name: None,
+            client_commit_hash: None,
+            server_environment_name: None,
+            server_commit_hash: None,
+        });
         assert!(body.contains("## Reporter"), "missing reporter section");
         assert!(
             body.contains("- Display Name: Hannah"),
@@ -659,19 +662,19 @@ mod tests {
 
     #[test]
     fn build_issue_body_always_includes_reporter_user_id() {
-        let body = build_issue_body(
-            "bug",
-            "Test",
-            None,
-            "auth0|xyz789",
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-        );
+        let body = build_issue_body(&IssueBodyParams {
+            issue_type: "bug",
+            description: "Test",
+            reporter_display_name: None,
+            reporter_user_id: "auth0|xyz789",
+            posthog_session_id: None,
+            user_agent: None,
+            page_url: None,
+            client_environment_name: None,
+            client_commit_hash: None,
+            server_environment_name: None,
+            server_commit_hash: None,
+        });
         assert!(
             body.contains("## Reporter"),
             "reporter section should always appear"
@@ -688,19 +691,19 @@ mod tests {
 
     #[test]
     fn build_issue_body_omits_environment_when_absent() {
-        let body = build_issue_body(
-            "bug",
-            "Test",
-            None,
-            "auth0|test",
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-        );
+        let body = build_issue_body(&IssueBodyParams {
+            issue_type: "bug",
+            description: "Test",
+            reporter_display_name: None,
+            reporter_user_id: "auth0|test",
+            posthog_session_id: None,
+            user_agent: None,
+            page_url: None,
+            client_environment_name: None,
+            client_commit_hash: None,
+            server_environment_name: None,
+            server_commit_hash: None,
+        });
         assert!(
             !body.contains("## Environment"),
             "environment section should not appear"
@@ -709,19 +712,19 @@ mod tests {
 
     #[test]
     fn build_issue_body_includes_both_client_and_server() {
-        let body = build_issue_body(
-            "bug",
-            "Test",
-            Some("hannah"),
-            "auth0|123abc",
-            Some("posthog-session-id"),
-            Some("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)"),
-            Some("http://localhost:3000/profile"),
-            Some("production"),
-            Some("123abc0"),
-            Some("production"),
-            Some("123abc0"),
-        );
+        let body = build_issue_body(&IssueBodyParams {
+            issue_type: "bug",
+            description: "Test",
+            reporter_display_name: Some("hannah"),
+            reporter_user_id: "auth0|123abc",
+            posthog_session_id: Some("posthog-session-id"),
+            user_agent: Some("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)"),
+            page_url: Some("http://localhost:3000/profile"),
+            client_environment_name: Some("production"),
+            client_commit_hash: Some("123abc0"),
+            server_environment_name: Some("production"),
+            server_commit_hash: Some("123abc0"),
+        });
         assert!(body.contains("## Reporter"), "missing reporter section");
         assert!(
             body.contains("- Display Name: hannah"),

--- a/src/services/github_issues.rs
+++ b/src/services/github_issues.rs
@@ -544,7 +544,17 @@ mod tests {
     #[test]
     fn build_issue_body_includes_footer() {
         let body = build_issue_body(
-            "bug", "Test", None, "auth0|test", None, None, None, None, None, None, None,
+            "bug",
+            "Test",
+            None,
+            "auth0|test",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
         );
         assert!(body.contains("Submitted via"), "footer not appended");
     }
@@ -650,7 +660,17 @@ mod tests {
     #[test]
     fn build_issue_body_always_includes_reporter_user_id() {
         let body = build_issue_body(
-            "bug", "Test", None, "auth0|xyz789", None, None, None, None, None, None, None,
+            "bug",
+            "Test",
+            None,
+            "auth0|xyz789",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
         );
         assert!(
             body.contains("## Reporter"),
@@ -669,7 +689,17 @@ mod tests {
     #[test]
     fn build_issue_body_omits_environment_when_absent() {
         let body = build_issue_body(
-            "bug", "Test", None, "auth0|test", None, None, None, None, None, None, None,
+            "bug",
+            "Test",
+            None,
+            "auth0|test",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
         );
         assert!(
             !body.contains("## Environment"),

--- a/src/services/github_issues.rs
+++ b/src/services/github_issues.rs
@@ -27,6 +27,12 @@ pub struct IssueRequest {
     pub user_agent: Option<String>,
     #[serde(default)]
     pub page_url: Option<String>,
+    #[serde(default)]
+    pub posthog_session_id: Option<String>,
+    #[serde(default)]
+    pub client_environment_name: Option<String>,
+    #[serde(default)]
+    pub client_commit_hash: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -130,30 +136,62 @@ fn build_issue_body(
     description: &str,
     reporter_display_name: Option<&str>,
     reporter_user_id: &str,
+    posthog_session_id: Option<&str>,
     user_agent: Option<&str>,
     page_url: Option<&str>,
-    commit_hash: Option<&str>,
+    client_environment_name: Option<&str>,
+    client_commit_hash: Option<&str>,
+    server_environment_name: Option<&str>,
+    server_commit_hash: Option<&str>,
 ) -> String {
     let template = get_template(issue_type);
     let body = template.body.replace("{description}", description);
     let mut result = body.trim_end().to_string();
 
+    // Reporter section
     result.push_str("\n\n## Reporter\n");
     if let Some(name) = reporter_display_name {
-        result.push_str(&format!("- Name: {}\n", name));
+        result.push_str(&format!("- Display Name: {}\n", name));
     }
     result.push_str(&format!("- User ID: `{}`\n", reporter_user_id));
+    if let Some(session_id) = posthog_session_id {
+        result.push_str(&format!("- Posthog Session ID: `{}`\n", session_id));
+    }
 
-    if user_agent.is_some() || page_url.is_some() || commit_hash.is_some() {
-        result.push_str("\n\n## Environment\n");
-        if let Some(ua) = user_agent {
-            result.push_str(&format!("- Browser: {}\n", ua));
+    // Environment section
+    let has_client = user_agent.is_some()
+        || page_url.is_some()
+        || client_environment_name.is_some()
+        || client_commit_hash.is_some();
+    let has_server = server_environment_name.is_some() || server_commit_hash.is_some();
+
+    if has_client || has_server {
+        result.push_str("\n## Environment\n");
+
+        if has_client {
+            result.push_str("\n### Client\n");
+            if let Some(ua) = user_agent {
+                result.push_str(&format!("- Browser: {}\n", ua));
+            }
+            if let Some(url) = page_url {
+                result.push_str(&format!("- URL: {}\n", url));
+            }
+            if let Some(env) = client_environment_name {
+                result.push_str(&format!("- Environment Name: `{}`\n", env));
+            }
+            if let Some(hash) = client_commit_hash {
+                result.push_str(&format!("- Commit Hash: `{}`\n", hash));
+            }
         }
-        if let Some(url) = page_url {
-            result.push_str(&format!("- URL: {}\n", url));
-        }
-        if let Some(hash) = commit_hash {
-            result.push_str(&format!("- Commit: `{}`\n", hash));
+
+        if has_server {
+            result.push_str("\n### Server\n");
+            if let Some(env) = server_environment_name {
+                result.push_str(&format!("- Environment Name: `{}`\n", env));
+            }
+            if let Some(hash) = server_commit_hash {
+                result.push_str(&format!("- Commit Hash: `{}`\n", hash));
+            }
         }
     }
 
@@ -215,7 +253,8 @@ pub struct GitHubIssueService {
     github_repo: String,
     turnstile_secret_key: Option<String>,
     turnstile_verify_url: String,
-    commit_hash: Option<String>,
+    server_commit_hash: Option<String>,
+    server_environment_name: Option<String>,
 }
 
 impl GitHubIssueService {
@@ -228,7 +267,8 @@ impl GitHubIssueService {
         github_repo: String,
         turnstile_secret_key: Option<String>,
         turnstile_verify_url: String,
-        commit_hash: Option<String>,
+        server_commit_hash: Option<String>,
+        server_environment_name: Option<String>,
     ) -> Self {
         Self {
             client: reqwest::Client::new(),
@@ -239,7 +279,8 @@ impl GitHubIssueService {
             github_repo,
             turnstile_secret_key,
             turnstile_verify_url,
-            commit_hash,
+            server_commit_hash,
+            server_environment_name,
         }
     }
 
@@ -383,9 +424,13 @@ impl GitHubIssueService {
                 &request.description,
                 reporter_display_name,
                 reporter_user_id,
+                request.posthog_session_id.as_deref(),
                 request.user_agent.as_deref(),
                 request.page_url.as_deref(),
-                self.commit_hash.as_deref(),
+                request.client_environment_name.as_deref(),
+                request.client_commit_hash.as_deref(),
+                self.server_environment_name.as_deref(),
+                self.server_commit_hash.as_deref(),
             ),
             labels: vec![issue_label(&request.issue_type)],
         };
@@ -484,6 +529,10 @@ mod tests {
             None,
             None,
             None,
+            None,
+            None,
+            None,
+            None,
         );
         assert!(
             body.contains("Test description here"),
@@ -494,25 +543,32 @@ mod tests {
 
     #[test]
     fn build_issue_body_includes_footer() {
-        let body = build_issue_body("bug", "Test", None, "auth0|test", None, None, None);
+        let body = build_issue_body(
+            "bug", "Test", None, "auth0|test", None, None, None, None, None, None, None,
+        );
         assert!(body.contains("Submitted via"), "footer not appended");
     }
 
     #[test]
-    fn build_issue_body_includes_environment_section() {
+    fn build_issue_body_includes_client_environment_section() {
         let body = build_issue_body(
             "bug",
             "Test",
             None,
             "auth0|test",
+            None,
             Some("Mozilla/5.0 (Macintosh)"),
             Some("https://wordles.dev/gamemaker"),
+            Some("production"),
+            Some("abc1234"),
+            None,
             None,
         );
         assert!(
             body.contains("## Environment"),
             "missing environment section"
         );
+        assert!(body.contains("### Client"), "missing client subsection");
         assert!(
             body.contains("- Browser: Mozilla/5.0 (Macintosh)"),
             "missing browser info"
@@ -520,6 +576,44 @@ mod tests {
         assert!(
             body.contains("- URL: https://wordles.dev/gamemaker"),
             "missing page URL"
+        );
+        assert!(
+            body.contains("- Environment Name: `production`"),
+            "missing client environment name"
+        );
+        assert!(
+            body.contains("- Commit Hash: `abc1234`"),
+            "missing client commit hash"
+        );
+    }
+
+    #[test]
+    fn build_issue_body_includes_server_environment_section() {
+        let body = build_issue_body(
+            "bug",
+            "Test",
+            None,
+            "auth0|test",
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some("production"),
+            Some("def5678"),
+        );
+        assert!(
+            body.contains("## Environment"),
+            "missing environment section"
+        );
+        assert!(body.contains("### Server"), "missing server subsection");
+        assert!(
+            body.contains("- Environment Name: `production`"),
+            "missing server environment name"
+        );
+        assert!(
+            body.contains("- Commit Hash: `def5678`"),
+            "missing server commit hash"
         );
     }
 
@@ -530,21 +624,34 @@ mod tests {
             "Test",
             Some("Hannah"),
             "auth0|abc123",
+            Some("posthog-session-123"),
+            None,
+            None,
+            None,
             None,
             None,
             None,
         );
         assert!(body.contains("## Reporter"), "missing reporter section");
-        assert!(body.contains("- Name: Hannah"), "missing reporter name");
+        assert!(
+            body.contains("- Display Name: Hannah"),
+            "missing reporter display name"
+        );
         assert!(
             body.contains("- User ID: `auth0|abc123`"),
             "missing reporter user ID"
+        );
+        assert!(
+            body.contains("- Posthog Session ID: `posthog-session-123`"),
+            "missing posthog session ID"
         );
     }
 
     #[test]
     fn build_issue_body_always_includes_reporter_user_id() {
-        let body = build_issue_body("bug", "Test", None, "auth0|xyz789", None, None, None);
+        let body = build_issue_body(
+            "bug", "Test", None, "auth0|xyz789", None, None, None, None, None, None, None,
+        );
         assert!(
             body.contains("## Reporter"),
             "reporter section should always appear"
@@ -554,14 +661,16 @@ mod tests {
             "user ID should always be present"
         );
         assert!(
-            !body.contains("- Name:"),
-            "name should be absent when not provided"
+            !body.contains("- Display Name:"),
+            "display name should be absent when not provided"
         );
     }
 
     #[test]
     fn build_issue_body_omits_environment_when_absent() {
-        let body = build_issue_body("bug", "Test", None, "auth0|test", None, None, None);
+        let body = build_issue_body(
+            "bug", "Test", None, "auth0|test", None, None, None, None, None, None, None,
+        );
         assert!(
             !body.contains("## Environment"),
             "environment section should not appear"
@@ -569,21 +678,36 @@ mod tests {
     }
 
     #[test]
-    fn build_issue_body_includes_commit_hash() {
+    fn build_issue_body_includes_both_client_and_server() {
         let body = build_issue_body(
             "bug",
             "Test",
-            None,
-            "auth0|test",
-            None,
-            None,
-            Some("abc1234"),
+            Some("hannah"),
+            "auth0|123abc",
+            Some("posthog-session-id"),
+            Some("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)"),
+            Some("http://localhost:3000/profile"),
+            Some("production"),
+            Some("123abc0"),
+            Some("production"),
+            Some("123abc0"),
+        );
+        assert!(body.contains("## Reporter"), "missing reporter section");
+        assert!(
+            body.contains("- Display Name: hannah"),
+            "missing display name"
         );
         assert!(
-            body.contains("## Environment"),
-            "missing environment section"
+            body.contains("- User ID: `auth0|123abc`"),
+            "missing user ID"
         );
-        assert!(body.contains("- Commit: `abc1234`"), "missing commit hash");
+        assert!(
+            body.contains("- Posthog Session ID: `posthog-session-id`"),
+            "missing posthog session ID"
+        );
+        assert!(body.contains("### Client"), "missing client subsection");
+        assert!(body.contains("### Server"), "missing server subsection");
+        assert!(body.contains("Submitted via"), "missing footer");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Split the issue body's Environment section into **Client** and **Server** subsections
- Frontend now sends `posthogSessionId`, `clientEnvironmentName`, and `clientCommitHash`
- Backend appends its own `serverEnvironmentName` and `serverCommitHash` from deployment context
- Renamed "Name" to "Display Name" in the Reporter section
- Updated OpenAPI schema, examples, and Bruno collection to reflect new fields

## Test plan
- [x] All 19 github_issues unit tests pass
- [x] Full cargo build + clippy + test suite passes (pre-commit hook)
- [x] Docker compose stack builds and runs (`BE_DIR=be/issue-report-metadata`)
- [ ] Submit an issue via the frontend and verify the new format in the GitHub issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)