### PR TITLE
Allow public read access to avatar bucket logo/ prefix

### DIFF
--- a/infra/lib/infra-stack.ts
+++ b/infra/lib/infra-stack.ts
@@ -7,6 +7,7 @@ import * as ecr from 'aws-cdk-lib/aws-ecr';
 import * as ecrAssets from 'aws-cdk-lib/aws-ecr-assets';
 import * as ecsPatterns from 'aws-cdk-lib/aws-ecs-patterns';
 import * as elbv2 from 'aws-cdk-lib/aws-elasticloadbalancingv2';
+import * as iam from 'aws-cdk-lib/aws-iam';
 import * as logs from 'aws-cdk-lib/aws-logs';
 import * as route53 from 'aws-cdk-lib/aws-route53';
 import * as s3 from 'aws-cdk-lib/aws-s3';
@@ -96,14 +97,31 @@ export class ScorekeeperStack extends cdk.Stack {
     );
 
     // S3 bucket for avatar uploads (private — accessed via pre-signed URLs)
+    // Public read access is allowed only for the "logo/" prefix (company logos for Auth0).
     const avatarBucketName = props?.avatarBucketName ?? 'scorekeeper-avatars';
     const avatarBucket = new s3.Bucket(this, 'AvatarBucket', {
       bucketName: avatarBucketName,
-      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      blockPublicAccess: new s3.BlockPublicAccess({
+        blockPublicAcls: true,
+        ignorePublicAcls: true,
+        blockPublicPolicy: false,
+        restrictPublicBuckets: false,
+      }),
       encryption: s3.BucketEncryption.S3_MANAGED,
       enforceSSL: true,
       removalPolicy: cdk.RemovalPolicy.RETAIN,
     });
+
+    // Allow anonymous read access to objects under the "logo/" prefix only
+    avatarBucket.addToResourcePolicy(
+      new iam.PolicyStatement({
+        sid: 'PublicReadLogos',
+        effect: iam.Effect.ALLOW,
+        principals: [new iam.StarPrincipal()],
+        actions: ['s3:GetObject'],
+        resources: [avatarBucket.arnForObjects('logo/*')],
+      })
+    );
 
     // S3 bucket for common words (private - used for puzzle word selection)
     const commonWordsBucketName = props?.commonWordsBucketName ?? 'scorekeeper-common-words';


### PR DESCRIPTION
## Summary
- Reuses the `scorekeeper-avatars` S3 bucket for company logos to display on the Auth0 login page
- Changes `blockPublicAccess` from `BLOCK_ALL` to a custom config that allows bucket policies while still blocking public ACLs
- Adds a resource policy granting anonymous `s3:GetObject` on the `logo/*` prefix only — all other objects remain private

## Test plan
- [ ] Verify `cdk diff` shows the expected policy changes (block public access config + new bucket policy statement)
- [ ] Deploy to staging and confirm uploading a file under `logo/` is publicly readable via direct S3 URL
- [ ] Confirm objects outside `logo/` (e.g. avatar uploads) remain inaccessible without a pre-signed URL
- [ ] Upload a logo and configure it in Auth0 to verify end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)