### PR TITLE
Fix PUT /profile response missing name and pronouns

### DIFF
--- a/src/routes/profile.rs
+++ b/src/routes/profile.rs
@@ -118,7 +118,7 @@ pub async fn update_profile(
         ));
     }
 
-    let user = auth0_service
+    auth0_service
         .update_user_metadata(
             &claims.sub,
             body.display_name.as_deref(),
@@ -127,6 +127,9 @@ pub async fn update_profile(
             body.pronouns.as_deref(),
         )
         .await?;
+
+    // Fetch the full user after PATCH — the PATCH response may omit user_metadata fields.
+    let user = auth0_service.get_user(&claims.sub).await?;
 
     let metadata = user.user_metadata.as_ref();
     let display_name = metadata.map(|m| m.display_name.clone());


### PR DESCRIPTION
## Summary
- The `update_profile` handler was building its response from the Auth0 PATCH response, which may omit `user_metadata` fields (including `name` and `pronouns`)
- After the PATCH, we now do a follow-up GET to fetch the complete user data before building the response
- This matches the pattern already used by the `get_profile` handler

## Test plan
- [x] `cargo test` — all 151 tests pass
- [x] Deploy and verify PUT /profile response includes `name` and `pronouns` fields
- [x] Verify GET /profile still returns all fields after an update

🤖 Generated with [Claude Code](https://claude.com/claude-code)