### PR TITLE
Fix: Reject duplicate guesses server-side (#118)

### DIFF
--- a/src/models/guess.rs
+++ b/src/models/guess.rs
@@ -313,4 +313,13 @@ mod tests {
         let date = NaiveDate::from_ymd_opt(2026, 1, 15).unwrap();
         assert_eq!(PuzzleAnswer::pk(date), "PUZZLE#2026-01-15");
     }
+
+    #[test]
+    fn test_game_state_duplicate_guess_detection() {
+        let date = NaiveDate::from_ymd_opt(2026, 1, 15).unwrap();
+        let mut state = GameState::new("auth0|123", date);
+        state.add_guess("crane");
+        assert!(state.guesses.contains(&"crane".to_string()));
+        assert!(!state.guesses.contains(&"slate".to_string()));
+    }
 }

--- a/src/routes/guess.rs
+++ b/src/routes/guess.rs
@@ -81,6 +81,11 @@ pub async fn submit_guess(
         return Err(AppError::bad_request("Game is already complete"));
     }
 
+    // Reject duplicate guesses
+    if game_state.guesses.contains(&guess) {
+        return Err(AppError::bad_request("You already guessed that word"));
+    }
+
     // Grade the guess
     let graded = grade_guess(&guess, &answer);
     let won = is_winning_guess(&graded);


### PR DESCRIPTION
## Summary
- Adds server-side validation in the `/guess` route handler to reject guesses that have already been submitted in the current game, returning a 400 error
- Adds a unit test verifying `Vec::contains` duplicate detection on `GameState.guesses`

## Test plan
- [x] `cargo test` passes (161 tests, including the new `test_game_state_duplicate_guess_detection`)
- [ ] Run `compose.sh up --build` and test in browser: submitting the same word twice returns a 400 error
- [ ] Curl the `/guess` endpoint twice with the same word to confirm 400 on the second attempt

🤖 Generated with [Claude Code](https://claude.com/claude-code)