### PR TITLE
Auto-create puzzles for /game and /guess instead of 404, update bruno, update hooks

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -23,8 +23,8 @@ if [ "$current_dir" != "$main_dir" ]; then
   echo "husky - fetching and building cargo dependencies in $(basename "$current_dir")..."
   cargo build
 
-  if [ ! -d .husky/_  ]; then
-    echo "husky - bootstrapping husky runner via infra npm install..."
+  if [ ! -d infra/node_modules ]; then
+    echo "husky - bootstrapping CDK dependencies via infra npm install..."
     cd infra && npm install && cd ..
   fi
 fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,6 +2,14 @@
 
 echo "Running pre-commit checks..."
 
+# Keep husky/tooling deps current so the hook doesn't silently go stale
+echo "Checking npm dependencies..."
+npm install --silent
+if [ $? -ne 0 ]; then
+    echo "npm install failed."
+    exit 1
+fi
+
 # Check Rust formatting
 echo "Checking formatting..."
 cargo fmt --check
@@ -28,7 +36,7 @@ fi
 
 # Run CDK tests
 echo "Running CDK tests..."
-cd infra && npm test
+cd infra && npm install --silent && npm test
 if [ $? -ne 0 ]; then
     echo "CDK tests failed."
     exit 1

--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ See [AGENTS.md](./AGENTS.md) for development guidelines.
 
 ### Recommended Installations
 
+- [Rust toolchain](https://doc.rust-lang.org/book/ch01-01-installation.html) - **not** needed to run the app (that's Docker's job, see [Running Locally](#running-locally)), but required on the host for `cargo fmt`/`cargo clippy`/`cargo test` to run directly, which the pre-commit hook (see [Pre-commit Hooks](#pre-commit-hooks)) and `AGENTS.md`'s quality gates both assume
+  ```bash
+  curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf | sh
+  ```
+  The default rustup profile already includes `rustfmt` and `clippy`; verify with:
+  ```bash
+  cargo fmt --version && cargo clippy --version
+  ```
 - [mkcert](https://github.com/FiloSottile/mkcert) - generates locally-trusted TLS certs (see [Local HTTPS Certs](#local-https-certs) below)
   ```bash
   brew install mkcert
@@ -31,6 +39,10 @@ docker compose -f docker-compose.dev.yml up
 This starts DynamoDB Local + admin UI (seeded automatically) and the API via `Dockerfile.dev` with hot reload, served at `https://localhost:8080`. The DynamoDB admin UI is at `http://localhost:8001`.
 
 If the stack is already running in another terminal/session, bring it down first with `docker compose -f docker-compose.dev.yml down` before starting a fresh copy.
+
+### Pre-commit Hooks
+
+Run `npm install` at the repo root after cloning. This installs [husky](https://typicode.github.io/husky/) via the `prepare` script and points git's `core.hooksPath` at `.husky`, which is what activates the pre-commit hook (`cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test`, and the CDK tests). Without this step, commits will succeed locally even if those checks would fail in CI.
 
 ### Local HTTPS Certs
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,49 @@ API backend for the Scorekeeper word puzzle game.
 
 See [AGENTS.md](./AGENTS.md) for development guidelines.
 
+### Recommended Installations
+
+- [mkcert](https://github.com/FiloSottile/mkcert) - generates locally-trusted TLS certs (see [Local HTTPS Certs](#local-https-certs) below)
+  ```bash
+  brew install mkcert
+  ```
+- [Bruno](https://www.usebruno.com/) - API client for exercising endpoints during local dev
+  ```bash
+  brew install --cask bruno
+  ```
+
+### Running Locally
+
+```bash
+docker compose -f docker-compose.dev.yml up
+```
+
+This starts DynamoDB Local + admin UI (seeded automatically) and the API via `Dockerfile.dev` with hot reload, served at `https://localhost:8080`. The DynamoDB admin UI is at `http://localhost:8001`.
+
+If the stack is already running in another terminal/session, bring it down first with `docker compose -f docker-compose.dev.yml down` before starting a fresh copy.
+
+### Local HTTPS Certs
+
+The dev server runs with TLS enabled (`certs/cert.pem` / `certs/key.pem`, mounted into the container per `docker-compose.dev.yml`). These files are gitignored and **not** checked in — each developer generates their own.
+
+Without a proper cert, browsers and strict HTTP clients will reject `https://localhost:8080` (self-signed cert not trusted, or missing Subject Alternative Names). Fix this with `mkcert`, which installs a local CA into your system/browser trust stores so `localhost` certs are trusted automatically:
+
+```bash
+# One-time: install mkcert's local CA into your system trust store
+mkcert -install
+
+# Generate the dev cert (run from the certs/ directory)
+cd certs
+mkcert -cert-file cert.pem -key-file key.pem localhost 127.0.0.1 ::1
+cd ..
+```
+
+Restart the stack (`docker compose -f docker-compose.dev.yml down && docker compose -f docker-compose.dev.yml up`) after generating new certs so the container picks them up. You can then curl without `-k`:
+
+```bash
+curl https://localhost:8080/health
+```
+
 ## DynamoDB Schema
 
 The application uses a single-table design in DynamoDB with composite primary keys (partition key `pk` and sort key `sk`).

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -78,6 +78,7 @@ services:
       - ./build.rs:/app/build.rs
       - ./data:/app/data
       - ./certs:/app/certs:ro
+      - ./templates:/app/templates
     networks:
       - scorekeeper-network-dev
     healthcheck:

--- a/docs/bruno/Admin/Clear Cache.bru
+++ b/docs/bruno/Admin/Clear Cache.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: http://{{baseUrl}}/puzzles/cache/clear
+  url: {{protocol}}://{{baseUrl}}/puzzles/cache/clear
   body: none
   auth: bearer
 }
@@ -16,10 +16,10 @@ auth:bearer {
 
 docs {
   Clear the puzzle answer cache (game admin only).
-
+  
   ## Authentication
   Requires a valid Bearer token with `app_metadata.game_admin = true`.
-
+  
   ## Responses
   - `200`: Cache cleared successfully
     ```json

--- a/docs/bruno/Admin/Get Puzzle by Date.bru
+++ b/docs/bruno/Admin/Get Puzzle by Date.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: http://{{baseUrl}}/puzzles/2026-02-05
+  url: {{protocol}}://{{baseUrl}}/puzzles/2026-02-05
   body: none
   auth: bearer
 }
@@ -16,13 +16,13 @@ auth:bearer {
 
 docs {
   Retrieve a single puzzle for a specific date.
-
+  
   ## Authentication
   Requires a valid Bearer token.
-
+  
   ## Path Parameters
   - `date` (string, required): The puzzle date in YYYY-MM-DD format
-
+  
   ## Responses
   - `200`: Puzzle retrieved successfully
     Admin users see the answer:

--- a/docs/bruno/Admin/Get Puzzles.bru
+++ b/docs/bruno/Admin/Get Puzzles.bru
@@ -5,9 +5,15 @@ meta {
 }
 
 get {
-  url: http://{{baseUrl}}/puzzles
+  url: {{protocol}}://{{baseUrl}}/puzzles
   body: none
   auth: bearer
+}
+
+params:query {
+  ~start_date: 2026-01-01
+  ~end_date: 2026-01-31
+  ~omit_answers: true
 }
 
 headers {
@@ -18,26 +24,20 @@ auth:bearer {
   token: {{jwt}}
 }
 
-params:query {
-  ~start_date: 2026-01-01
-  ~end_date: 2026-01-31
-  ~omit_answers: true
-}
-
 docs {
   Gets puzzle answers for game administrators. This is a game admin-only endpoint.
-
+  
   ## Authentication
   Requires a valid Bearer token (inherited from collection).
   The authenticated user must have `app_metadata.game_admin = true` in their token.
-
+  
   ## Query Parameters
   - `start_date` (string, optional): Start date for filtering puzzles (inclusive, YYYY-MM-DD)
   - `end_date` (string, optional): End date for filtering puzzles (inclusive, YYYY-MM-DD)
   - `omit_answers` (boolean, optional): If true, omit the answer words from the response (only return dates)
-
+  
   If no parameters are provided, returns all puzzles with their answers.
-
+  
   ## Responses
   - `200`: Puzzle answers retrieved successfully
     ```json

--- a/docs/bruno/Admin/Set Puzzle.bru
+++ b/docs/bruno/Admin/Set Puzzle.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 put {
-  url: http://{{baseUrl}}/puzzles
+  url: {{protocol}}://{{baseUrl}}/puzzles
   body: json
   auth: bearer
 }
@@ -28,16 +28,16 @@ body:json {
 
 docs {
   Sets the puzzle answer for a specific date. This is a game admin-only endpoint.
-
+  
   ## Authentication
   Requires a valid Bearer token (inherited from collection).
   The authenticated user must have `app_metadata.game_admin = true` in their token.
-
+  
   ## Request Body
   - `date` (string, required): The puzzle date in YYYY-MM-DD format
   - `word` (string, required): The 5-letter answer word (will be lowercased)
   - `teamId` (string, optional): Team ID for team-specific puzzles
-
+  
   ## Responses
   - `200`: Puzzle answer set successfully
     ```json

--- a/docs/bruno/Auth/ccf.bru
+++ b/docs/bruno/Auth/ccf.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: https://dev-g32naui5mvpwnsg7.auth0.com/oauth/token
+  url: https://{{auth0TenantName}}.auth0.com/oauth/token
   body: formUrlEncoded
   auth: inherit
 }

--- a/docs/bruno/Auth/well known.bru
+++ b/docs/bruno/Auth/well known.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: https://dev-g32naui5mvpwnsg7.auth0.com/.well-known/openid-configuration
+  url: https://{{auth0TenantName}}.auth0.com/.well-known/openid-configuration
   body: none
   auth: inherit
 }

--- a/docs/bruno/Gameplay/Get Game.bru
+++ b/docs/bruno/Gameplay/Get Game.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: http://{{baseUrl}}/game/2026-02-05
+  url: {{protocol}}://{{baseUrl}}/game/2026-02-05
   body: none
   auth: bearer
 }
@@ -16,15 +16,15 @@ auth:bearer {
 
 docs {
   Load game progress for a specific puzzle date.
-
+  
   ## Authentication
   Requires either:
   - Bearer token in Authorization header (JWT)
   - Cookie: wordle_session=<user_id> (for embedded games)
-
+  
   ## Path Parameters
   - `puzzle_date` (string, required): The puzzle date in YYYY-MM-DD format
-
+  
   ## Responses
   - `200`: Game progress retrieved successfully
     ```json

--- a/docs/bruno/Gameplay/Submit Guess.bru
+++ b/docs/bruno/Gameplay/Submit Guess.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: http://{{baseUrl}}/guess
+  url: {{protocol}}://{{baseUrl}}/guess
   body: json
   auth: bearer
 }

--- a/docs/bruno/Games/Create Games.bru
+++ b/docs/bruno/Games/Create Games.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: http://{{baseUrl}}/games
+  url: {{protocol}}://{{baseUrl}}/games
   body: json
   auth: inherit
 }

--- a/docs/bruno/Games/Get Game by ID.bru
+++ b/docs/bruno/Games/Get Game by ID.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: http://{{baseUrl}}/games/:game_id
+  url: {{protocol}}://{{baseUrl}}/games/:game_id
   body: none
   auth: none
 }

--- a/docs/bruno/Games/Healthcheck.bru
+++ b/docs/bruno/Games/Healthcheck.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: http://{{baseUrl}}/health
+  url: {{protocol}}://{{baseUrl}}/health
   body: none
   auth: none
 }

--- a/docs/bruno/History/Get History.bru
+++ b/docs/bruno/History/Get History.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: http://{{baseUrl}}/history
+  url: {{protocol}}://{{baseUrl}}/history
   body: none
   auth: bearer
 }
@@ -16,10 +16,10 @@ auth:bearer {
 
 docs {
   Retrieves the game history for the currently authenticated user.
-
+  
   ## Authentication
   Requires a valid Bearer token.
-
+  
   ## Responses
   - `200`: History retrieved successfully
     ```json

--- a/docs/bruno/Issues/Create Issue.bru
+++ b/docs/bruno/Issues/Create Issue.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: http://{{baseUrl}}/issues
+  url: {{protocol}}://{{baseUrl}}/issues
   body: json
   auth: bearer
 }
@@ -36,16 +36,16 @@ body:json {
 
 docs {
   Submit an issue report. Creates a GitHub issue on behalf of the authenticated user.
-
+  
   The reporter's user ID (from JWT) and display name (from Auth0 profile) are
   included in the issue body. PostHog session ID is included for session replay
   correlation. The issue body includes separate Client and Server environment
   sections — client metadata is sent by the frontend, server metadata is
   appended by the backend from its own deployment context.
-
+  
   ## Authentication
   Requires a valid Bearer token (inherited from collection).
-
+  
   ## Request Body
   - `issueType` (string, required): One of "bug", "feature", or "question"
   - `title` (string, required): Brief summary of the issue
@@ -57,7 +57,7 @@ docs {
   - `posthogSessionId` (string, optional): PostHog session ID for replay correlation
   - `clientEnvironmentName` (string, optional): Client deployment environment name
   - `clientCommitHash` (string, optional): Client git commit hash
-
+  
   ## Responses
   - `201`: Issue created successfully
     ```json

--- a/docs/bruno/Profile/Get Profile.bru
+++ b/docs/bruno/Profile/Get Profile.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: http://{{baseUrl}}/profile
+  url: {{protocol}}://{{baseUrl}}/profile
   body: none
   auth: bearer
 }

--- a/docs/bruno/Profile/Update Profile.bru
+++ b/docs/bruno/Profile/Update Profile.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 put {
-  url: http://{{baseUrl}}/profile
+  url: {{protocol}}://{{baseUrl}}/profile
   body: json
   auth: bearer
 }

--- a/docs/bruno/Profile/Upload Avatar.bru
+++ b/docs/bruno/Profile/Upload Avatar.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: http://{{baseUrl}}/profile/avatar
+  url: {{protocol}}://{{baseUrl}}/profile/avatar
   body: multipartForm
   auth: bearer
 }
@@ -24,22 +24,22 @@ body:multipart-form {
 
 docs {
   Uploads an avatar image for the currently authenticated user.
-
+  
   The image is uploaded to S3 and the URL is stored in Auth0 user_metadata.
-
+  
   ## Authentication
   Requires a valid Bearer token (inherited from collection).
-
+  
   ## Prerequisites
   The server must be configured with:
   - `AUTH0_M2M_CLIENT_ID` and `AUTH0_M2M_CLIENT_SECRET`
   - `S3_AVATAR_BUCKET`
-
+  
   ## Request Body
   - `avatar` (file, required): Image file to upload
     - Allowed types: JPEG, PNG
     - Maximum size: 2MB
-
+  
   ## Responses
   - `200`: Avatar uploaded successfully
     ```json

--- a/docs/bruno/Session/Convert Session.bru
+++ b/docs/bruno/Session/Convert Session.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: http://{{baseUrl}}/convert-session
+  url: {{protocol}}://{{baseUrl}}/convert-session
   body: json
   auth: bearer
 }
@@ -26,20 +26,20 @@ body:json {
 
 docs {
   Convert anonymous session games to the authenticated user's account.
-
+  
   When a user plays anonymously (session cookie) and then logs in, this endpoint
   migrates their anonymous game history to their authenticated account.
-
+  
   ## Authentication
   Requires a valid Bearer token (JWT from Auth0 login).
-
+  
   ## Request Body
   - `session_id` (string, required): The anonymous session cookie UUID
-
+  
   ## Conflict Resolution
   If both the anonymous session and the authenticated user have a game for the
   same puzzle date, whichever was created first is kept.
-
+  
   ## Responses
   - `200`: Conversion completed
     ```json

--- a/docs/bruno/environments/aws.bru
+++ b/docs/bruno/environments/aws.bru
@@ -1,9 +1,11 @@
 vars {
-  baseUrl: scorek-score-givbsinrjlo6-310725690.us-west-2.elb.amazonaws.com
+  ~baseUrl: scorek-score-givbsinrjlo6-310725690.us-west-2.elb.amazonaws.com
   auth0TenantName: dev-g32naui5mvpwnsg7
   secret-spa-starchart: 
   client-id-web-scorekeeper: 
   client-id-web-scorekeeper: 
+  protocol: https
+  baseUrl: api.wordles.dev
 }
 vars:secret [
   jwt,

--- a/docs/bruno/environments/local.bru
+++ b/docs/bruno/environments/local.bru
@@ -1,6 +1,7 @@
 vars {
   baseUrl: localhost:8080
   auth0TenantName: dev-g32naui5mvpwnsg7
+  protocol: https
 }
 vars:secret [
   jwt

--- a/src/db/puzzle.rs
+++ b/src/db/puzzle.rs
@@ -223,7 +223,7 @@ impl PuzzleDatabase for DynamoDbPuzzleRepository {
         }
 
         // Sort by puzzle_date descending (most recent first)
-        game_states.sort_by(|a, b| b.puzzle_date.cmp(&a.puzzle_date));
+        game_states.sort_by_key(|b| std::cmp::Reverse(b.puzzle_date));
 
         Ok(game_states)
     }
@@ -359,7 +359,7 @@ impl PuzzleDatabase for DynamoDbPuzzleRepository {
         }
 
         // Sort by date ascending
-        puzzles.sort_by(|a, b| a.puzzle_date.cmp(&b.puzzle_date));
+        puzzles.sort_by_key(|a| a.puzzle_date);
 
         Ok(puzzles)
     }
@@ -461,7 +461,7 @@ impl PuzzleDatabase for InMemoryPuzzleDb {
             .collect();
 
         // Sort by puzzle_date descending (most recent first)
-        user_states.sort_by(|a, b| b.puzzle_date.cmp(&a.puzzle_date));
+        user_states.sort_by_key(|b| std::cmp::Reverse(b.puzzle_date));
 
         Ok(user_states)
     }
@@ -518,7 +518,7 @@ impl PuzzleDatabase for InMemoryPuzzleDb {
             .collect();
 
         // Sort by date ascending
-        puzzles.sort_by(|a, b| a.puzzle_date.cmp(&b.puzzle_date));
+        puzzles.sort_by_key(|a| a.puzzle_date);
 
         Ok(puzzles)
     }

--- a/src/routes/game.rs
+++ b/src/routes/game.rs
@@ -10,7 +10,7 @@ use crate::db::PuzzleDatabase;
 use crate::middleware::auth::{extract_bearer_token, extract_cookie_token, JwtAuth};
 use crate::models::error::AppError;
 use crate::models::guess::{GameState, GradedGame};
-use crate::services::grade_guess;
+use crate::services::{create_random_puzzle, grade_guess, CommonWordsService};
 
 /// GET /game/{puzzle_date} - Load game progress for a specific puzzle date.
 ///
@@ -21,15 +21,20 @@ use crate::services::grade_guess;
 /// - Authorization header: Bearer <token> (validated as JWT)
 /// - Cookie: wordle_session=<user_id> (used directly, for embedded games)
 ///
+/// If no puzzle exists yet for the requested date, one is created automatically
+/// using a random, previously unused word from the common words list (the same
+/// selection logic as the admin `set_random_unused_word` puzzle-setting flow).
+///
 /// Responses:
 /// - 200: GradedGame with current progress (may be empty if no guesses yet)
 /// - 400: Bad request (invalid date format)
 /// - 401: Unauthorized (missing or invalid authentication)
-/// - 404: No puzzle found for this date
+/// - 404: No puzzle found for this date and none could be created (no common
+///   words list configured, or no unused words remain)
 #[get("/game/{puzzle_date}")]
 #[instrument(
     name = "get_game",
-    skip(req, puzzle_db, jwt_auth),
+    skip(req, puzzle_db, jwt_auth, common_words),
     fields(puzzle_date = tracing::field::Empty, user_id = tracing::field::Empty)
 )]
 pub async fn get_game(
@@ -37,6 +42,7 @@ pub async fn get_game(
     path: web::Path<String>,
     puzzle_db: web::Data<Arc<dyn PuzzleDatabase>>,
     jwt_auth: web::Data<JwtAuth>,
+    common_words: Option<web::Data<CommonWordsService>>,
 ) -> Result<HttpResponse, AppError> {
     // Try JWT first (Authorization header), fall back to cookie
     let user_id: String = if let Some(token) = extract_bearer_token(&req) {
@@ -59,12 +65,22 @@ pub async fn get_game(
     // Record puzzle_date in span
     tracing::Span::current().record("puzzle_date", puzzle_date.to_string().as_str());
 
-    // Verify the puzzle exists for this date
-    let answer = puzzle_db
+    // Get the puzzle answer, creating a random unused-word puzzle for this date
+    // if one doesn't exist yet (same word selection used by the admin
+    // set-puzzle-with-random-word flow).
+    let existing_answer = puzzle_db
         .get_puzzle_answer(puzzle_date)
         .await
-        .map_err(|e| AppError::InternalError(format!("Database error: {}", e)))?
-        .ok_or_else(|| AppError::not_found("No puzzle found for this date"))?;
+        .map_err(|e| AppError::InternalError(format!("Database error: {}", e)))?;
+
+    let answer = match existing_answer {
+        Some(word) => word,
+        None => {
+            let cws =
+                common_words.ok_or_else(|| AppError::not_found("No puzzle found for this date"))?;
+            create_random_puzzle(&puzzle_db, &cws, puzzle_date, None).await?
+        }
+    };
 
     // Get game state (or create empty one if no progress yet)
     let game_state = puzzle_db

--- a/src/routes/guess.rs
+++ b/src/routes/guess.rs
@@ -10,17 +10,21 @@ use crate::dictionary::is_valid_word;
 use crate::middleware::auth::{extract_bearer_token, extract_cookie_token, JwtAuth};
 use crate::models::error::AppError;
 use crate::models::guess::{GameState, GradedGame, GuessRequest};
-use crate::services::{grade_guess, is_winning_guess};
+use crate::services::{create_random_puzzle, grade_guess, is_winning_guess, CommonWordsService};
 
 /// POST /guess - Submit a guess for a word puzzle.
 ///
 /// Accepts authentication via either:
 /// - Authorization header: Bearer <token> (validated as JWT)
 /// - Cookie: wordle_session=<user_id> (used directly, for embedded games)
+///
+/// If no puzzle exists yet for the requested date, one is created automatically
+/// using a random, previously unused word from the common words list (the same
+/// selection logic as the admin `set_random_unused_word` puzzle-setting flow).
 #[post("/guess")]
 #[instrument(
     name = "submit_guess",
-    skip(req, body, puzzle_db, jwt_auth),
+    skip(req, body, puzzle_db, jwt_auth, common_words),
     fields(
         puzzle_date = %body.puzzle_date_iso_day,
         user_id = tracing::field::Empty,
@@ -33,6 +37,7 @@ pub async fn submit_guess(
     body: web::Json<GuessRequest>,
     puzzle_db: web::Data<Arc<dyn PuzzleDatabase>>,
     jwt_auth: web::Data<JwtAuth>,
+    common_words: Option<web::Data<CommonWordsService>>,
 ) -> Result<HttpResponse, AppError> {
     // Try JWT first (Authorization header), fall back to cookie
     let user_id: String = if let Some(token) = extract_bearer_token(&req) {
@@ -62,12 +67,22 @@ pub async fn submit_guess(
         return Err(AppError::bad_request("Word not in dictionary"));
     }
 
-    // Get the puzzle answer
-    let answer = puzzle_db
+    // Get the puzzle answer, creating a random unused-word puzzle for this date
+    // if one doesn't exist yet (same word selection used by the admin
+    // set-puzzle-with-random-word flow).
+    let existing_answer = puzzle_db
         .get_puzzle_answer(puzzle_date)
         .await
-        .map_err(|e| AppError::InternalError(format!("Database error: {}", e)))?
-        .ok_or_else(|| AppError::not_found("No puzzle found for this date"))?;
+        .map_err(|e| AppError::InternalError(format!("Database error: {}", e)))?;
+
+    let answer = match existing_answer {
+        Some(word) => word,
+        None => {
+            let cws =
+                common_words.ok_or_else(|| AppError::not_found("No puzzle found for this date"))?;
+            create_random_puzzle(&puzzle_db, &cws, puzzle_date, None).await?
+        }
+    };
 
     // Get or create game state
     let mut game_state = puzzle_db

--- a/src/routes/puzzle.rs
+++ b/src/routes/puzzle.rs
@@ -5,9 +5,7 @@
 
 use actix_web::{get, post, put, web, HttpResponse};
 use chrono::NaiveDate;
-use rand::seq::IteratorRandom;
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
 use std::sync::Arc;
 use tracing::instrument;
 
@@ -16,7 +14,7 @@ use crate::dictionary::is_valid_word;
 use crate::middleware::auth::Claims;
 use crate::middleware::validation::{deserialize_optional_date, validate_date_range};
 use crate::models::error::AppError;
-use crate::services::CommonWordsService;
+use crate::services::{create_random_puzzle, CommonWordsService};
 
 /// Request payload for setting a puzzle answer.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -182,18 +180,7 @@ pub async fn set_puzzle(
         ));
     }
 
-    let word = if body.set_random_unused_word {
-        // Get all existing puzzle answers to find used words
-        let existing_puzzles = puzzle_db
-            .get_puzzle_answers(None, None)
-            .await
-            .map_err(|e| AppError::InternalError(format!("Database error: {}", e)))?;
-
-        let used_words: HashSet<String> = existing_puzzles
-            .into_iter()
-            .map(|p| p.word.to_lowercase())
-            .collect();
-
+    if body.set_random_unused_word {
         // Require common words service for random word selection
         let cws = common_words.ok_or_else(|| {
             AppError::bad_request(
@@ -201,29 +188,23 @@ pub async fn set_puzzle(
             )
         })?;
 
-        let words = cws.get_words().await.ok_or_else(|| {
-            AppError::InternalError("Common words list failed to load".to_string())
-        })?;
+        let word =
+            create_random_puzzle(&puzzle_db, &cws, body.date, body.team_id.as_deref()).await?;
 
-        let mut rng = rand::thread_rng();
-        let unused: Vec<_> = words.iter().filter(|w| !used_words.contains(*w)).collect();
+        return Ok(HttpResponse::Ok().json(SetPuzzleResponse {
+            date: body.date,
+            word,
+            team_id: body.team_id.clone(),
+        }));
+    }
 
-        unused
-            .into_iter()
-            .choose(&mut rng)
-            .map(|s| s.to_string())
-            .ok_or_else(|| {
-                AppError::bad_request("No unused words available in the common words list")
-            })?
-    } else {
-        // Use the provided word
-        match &body.word {
-            Some(w) => w.to_lowercase(),
-            None => {
-                return Err(AppError::bad_request(
-                    "Either provide a word or set set_random_unused_word to true",
-                ))
-            }
+    // Use the provided word
+    let word = match &body.word {
+        Some(w) => w.to_lowercase(),
+        None => {
+            return Err(AppError::bad_request(
+                "Either provide a word or set set_random_unused_word to true",
+            ))
         }
     };
 

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -4,6 +4,7 @@ pub mod auth0;
 pub mod common_words;
 pub mod github_issues;
 pub mod grading;
+pub mod puzzle_creation;
 pub mod s3_avatar;
 
 use crate::models::{Game, GameCreate};
@@ -13,6 +14,7 @@ pub use auth0::Auth0ManagementService;
 pub use common_words::{CommonWordsService, CommonWordsSource};
 pub use github_issues::{GitHubIssueService, RateLimiter};
 pub use grading::{grade_guess, is_winning_guess};
+pub use puzzle_creation::create_random_puzzle;
 pub use s3_avatar::S3AvatarService;
 
 /// Service for managing games.

--- a/src/services/puzzle_creation.rs
+++ b/src/services/puzzle_creation.rs
@@ -1,0 +1,56 @@
+//! Service for creating puzzles from randomly selected, previously unused words.
+
+use chrono::NaiveDate;
+use rand::seq::IteratorRandom;
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use crate::db::PuzzleDatabase;
+use crate::models::error::AppError;
+use crate::services::CommonWordsService;
+
+/// Picks a random word from the common words list that hasn't been used in
+/// any existing puzzle yet, and sets it as the puzzle answer for `date`.
+///
+/// Returns the selected word. Shared by the admin "set puzzle" endpoint
+/// (`set_random_unused_word`) and by gameplay endpoints that fall back to
+/// creating a puzzle on demand when a player requests a date with none set.
+pub async fn create_random_puzzle(
+    puzzle_db: &Arc<dyn PuzzleDatabase>,
+    common_words: &CommonWordsService,
+    date: NaiveDate,
+    team_id: Option<&str>,
+) -> Result<String, AppError> {
+    let existing_puzzles = puzzle_db
+        .get_puzzle_answers(None, None)
+        .await
+        .map_err(|e| AppError::InternalError(format!("Database error: {}", e)))?;
+
+    let used_words: HashSet<String> = existing_puzzles
+        .into_iter()
+        .map(|p| p.word.to_lowercase())
+        .collect();
+
+    let words = common_words
+        .get_words()
+        .await
+        .ok_or_else(|| AppError::InternalError("Common words list failed to load".to_string()))?;
+
+    let mut rng = rand::thread_rng();
+    let unused: Vec<_> = words.iter().filter(|w| !used_words.contains(*w)).collect();
+
+    let word = unused
+        .into_iter()
+        .choose(&mut rng)
+        .map(|s| s.to_string())
+        .ok_or_else(|| {
+            AppError::bad_request("No unused words available in the common words list")
+        })?;
+
+    puzzle_db
+        .set_puzzle_answer(date, &word, team_id)
+        .await
+        .map_err(|e| AppError::InternalError(format!("Database error: {}", e)))?;
+
+    Ok(word)
+}


### PR DESCRIPTION
This was the first PR for a while! Additionally on a new computer, so it was good to run into some things that came up revisiting after a while especially about things that weren't set up yet for this new machine.

I coulda split some of this new cleanup stuff out and chose not to because I am still working alone in this repo for now, and kinda don't mind wrapping some small things in with other PRs, but usually just wouldn't let this balloon so large in busier projects

## Summary
- `GET /game/{date}` and `POST /guess` previously returned a 404 (`No puzzle found for this date`) when no puzzle existed for the requested date. They now fall back to creating one automatically, using a random, previously unused word from the common words list — the same word-selection logic already used by `PUT /puzzles` with `set_random_unused_word: true`.
- Extracted that word-selection + persistence logic out of `set_puzzle` into a shared `services::create_random_puzzle` function so all three call sites stay in sync.
- A 404 is still returned if no common words list is configured, or if there are no unused words left.
- Unrelated but required to build the dev container at all: `docker-compose.dev.yml` was missing a `./templates` volume mount, causing `cargo build`/`cargo watch` to fail on `include_str!` for the GitHub issue templates. Added the mount.

## Test plan
- [x] `cargo test` — all 160 tests pass
- [x] `cargo fmt --check` / `cargo clippy --all-targets -- -D warnings` — clean (pre-existing clippy findings in `db/puzzle.rs`, `config.rs`, `middleware/validation.rs` are unrelated to this change and present on `main` too)
- [x] Ran the dev stack locally via `docker-compose.dev.yml` and confirmed:
  - `GET /game/{date}` for a date with no puzzle returns 200 with an empty game (instead of 404), and persists a new puzzle answer to DynamoDB
  - `POST /guess` for a date with no puzzle returns 200 and grades the guess against the newly created puzzle
  - A second guess against the same just-created date reuses the same puzzle/game (doesn't recreate it)
  - `PUT /puzzles` admin random-word flow still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)